### PR TITLE
Codestyle review

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 datasets = "2.20.0"
+ruff = "^0.6.4"
 
 [tool.poetry.group.test]
 optional = true
@@ -32,10 +33,6 @@ pytest = "8.3.2"
 [tool.poetry.scripts]
 "autointent" = "autointent.pipeline.main:main"
 "clear-cache" = "autointent.cache_utils:clear_chroma_cache"
-
-[tool.ruff]
-line-length = 120
-indent-width = 4
 
 [build-system]
 requires = ["poetry-core"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,11 @@
+line-length = 120
+indent-width = 4
+
+target-version = "py310"
+
+[lint]
+select = ["ALL"]
+ignore = ["D", "TD", "ANN", "FIX", "S311"]
+
+[lint.per-file-ignores]
+"__init__.py" = ["F401"]


### PR DESCRIPTION
Проблемы, которые нашла команда `ruff check ./autointent`.
Из основного:
- надо определиться со стилем импортов в проекте,
- советую перейти с `os` на `pathlib`.

TID252 (71) — https://docs.astral.sh/ruff/rules/relative-imports/
RET504 (27) — https://docs.astral.sh/ruff/rules/unnecessary-assign/
COM812 (26) — https://docs.astral.sh/ruff/rules/missing-trailing-comma/
RUF013 (22) — https://docs.astral.sh/ruff/rules/implicit-optional/
C408 (18) — https://docs.astral.sh/ruff/rules/unnecessary-collection-call/
B905 (18) — https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/
I001 (15) — https://docs.astral.sh/ruff/rules/unsorted-imports/
E501 (13) — https://docs.astral.sh/ruff/rules/line-too-long/
RUF012 (10) — https://docs.astral.sh/ruff/rules/mutable-class-default/
ERA001 (9) — https://docs.astral.sh/ruff/rules/commented-out-code/
W292 (9) — https://docs.astral.sh/ruff/rules/missing-newline-at-end-of-file/
SLF001 (8) — https://docs.astral.sh/ruff/rules/private-member-access/
PTH123 (8) — https://docs.astral.sh/ruff/rules/builtin-open/
PTH118 (8) — https://docs.astral.sh/ruff/rules/os-path-join/
RUF005 (6) — https://docs.astral.sh/ruff/rules/collection-literal-concatenation/
FBT001 (6) — https://docs.astral.sh/ruff/rules/boolean-type-hint-positional-argument/
B028 (6) — https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/
SIM115 (6) — https://docs.astral.sh/ruff/rules/open-file-with-context-handler/
S101 (5) — https://docs.astral.sh/ruff/rules/assert/
FBT002 (5) — https://docs.astral.sh/ruff/rules/boolean-default-value-positional-argument/
PLR2004 (5) — https://docs.astral.sh/ruff/rules/magic-value-comparison/
T201 (5) — https://docs.astral.sh/ruff/rules/print/
PLW2901 (4) — https://docs.astral.sh/ruff/rules/redefined-loop-name/
W293 (4) — https://docs.astral.sh/ruff/rules/blank-line-with-whitespace/
PLR0913 (3) — https://docs.astral.sh/ruff/rules/too-many-arguments/
TRY003 (3) — https://docs.astral.sh/ruff/rules/raise-vanilla-args/
UP035 (3) — https://docs.astral.sh/ruff/rules/deprecated-import/
PIE790 (3) — https://docs.astral.sh/ruff/rules/unnecessary-placeholder/
E402 (2) — https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file/
EM101 (2) — https://docs.astral.sh/ruff/rules/raw-string-in-exception/
SIM108 (2) — https://docs.astral.sh/ruff/rules/if-else-block-instead-of-if-exp/
ARG002 (2) — https://docs.astral.sh/ruff/rules/unused-method-argument/
ARG001 (2) — https://docs.astral.sh/ruff/rules/unused-function-argument/
PTH110 (2) — https://docs.astral.sh/ruff/rules/os-path-exists/
PTH103 (2) — https://docs.astral.sh/ruff/rules/os-makedirs/
EM102 (1) — https://docs.astral.sh/ruff/rules/f-string-in-exception/
PERF203 (1) — https://docs.astral.sh/ruff/rules/try-except-in-loop/
RET505 (1) — https://docs.astral.sh/ruff/rules/superfluous-else-return/
T203 (1) — https://docs.astral.sh/ruff/rules/p-print/
RET503 (1) — https://docs.astral.sh/ruff/rules/implicit-return/
C401 (1) — https://docs.astral.sh/ruff/rules/unnecessary-generator-set/
Q000 (1) — https://docs.astral.sh/ruff/rules/bad-quotes-inline-string/
A002 (1) — https://docs.astral.sh/ruff/rules/builtin-argument-shadowing/
TCH001 (1) — https://docs.astral.sh/ruff/rules/typing-only-first-party-import/
DTZ005 (1) — https://docs.astral.sh/ruff/rules/call-datetime-now-without-tzinfo/
PTH109 (1) — https://docs.astral.sh/ruff/rules/os-getcwd/
PTH120 (1) — https://docs.astral.sh/ruff/rules/os-path-dirname/
W291 (1) — https://docs.astral.sh/ruff/rules/trailing-whitespace/

Пока отключил группы правил, которые проверяют документацию и типизацию. С ними много проблем.