### PR TITLE
Test/pipeline simpler fitting

### DIFF
--- a/autointent/context/optimization_info/optimization_info.py
+++ b/autointent/context/optimization_info/optimization_info.py
@@ -123,7 +123,7 @@ class OptimizationInfo:
             trial = self.trials.get_trial(node_type, idx)
             res.append(
                 InferenceNodeConfig(
-                    node_type=node_type,
+                    node_type=node_type.value,
                     module_type=trial.module_type,
                     module_config=trial.module_params,
                     load_path=trial.module_dump_dir,

--- a/autointent/pipeline/inference/cli_endpoint.py
+++ b/autointent/pipeline/inference/cli_endpoint.py
@@ -29,7 +29,7 @@ def main(cfg: InferenceConfig) -> None:
     logger.debug("Inference config loaded")
 
     # instantiate pipeline
-    pipeline = InferencePipeline.from_config(inference_config["nodes_configs"])
+    pipeline = InferencePipeline.from_dict_config(inference_config["nodes_configs"])
 
     # send data to pipeline
     labels: list[LabelType] = pipeline.predict(data)

--- a/autointent/pipeline/inference/inference_pipeline.py
+++ b/autointent/pipeline/inference/inference_pipeline.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from autointent.configs.node import InferenceNodeConfig
 from autointent.context import Context
 from autointent.custom_types import LabelType, NodeType
@@ -7,6 +9,12 @@ from autointent.nodes.inference import InferenceNode
 class InferencePipeline:
     def __init__(self, nodes: list[InferenceNode]) -> None:
         self.nodes = {node.node_type: node for node in nodes}
+
+    @classmethod
+    def from_dict_config(cls, nodes_configs: list[dict[str, Any]]) -> "InferencePipeline":
+        nodes_configs_ = [InferenceNodeConfig(**cfg) for cfg in nodes_configs]
+        nodes = [InferenceNode.from_config(cfg) for cfg in nodes_configs_]
+        return cls(nodes)
 
     @classmethod
     def from_config(cls, nodes_configs: list[InferenceNodeConfig]) -> "InferencePipeline":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,8 @@ from autointent.context.utils import load_data
 
 
 def setup_environment() -> tuple[str, str]:
-    logs_dir = ires.files("tests").joinpath("logs")
-    db_dir = logs_dir / "db" / str(uuid4())
+    logs_dir = ires.files("tests").joinpath("logs") / str(uuid4())
+    db_dir = logs_dir / "db"
     dump_dir = logs_dir / "modules_dump"
     return db_dir, dump_dir, logs_dir
 

--- a/tests/pipeline/test_inference.py
+++ b/tests/pipeline/test_inference.py
@@ -91,7 +91,9 @@ def test_inference_pipeline_cli(dataset, task_type):
 
     pipeline_optimizer = PipelineOptimizer.from_dict_config(search_space)
 
-    pipeline_optimizer.set_config(LoggingConfig(dirpath=Path(logs_dir).resolve(), dump_dir=dump_dir, dump_modules=True))
+    pipeline_optimizer.set_config(
+        logging_config := LoggingConfig(dirpath=Path(logs_dir).resolve(), dump_dir=dump_dir, dump_modules=True)
+    )
     pipeline_optimizer.set_config(VectorIndexConfig(db_dir=Path(db_dir).resolve(), device="cuda", save_db=True))
     pipeline_optimizer.set_config(EmbedderConfig(batch_size=16, max_length=32))
     context = pipeline_optimizer.optimize_from_dataset(dataset, force_multilabel=(task_type == "multilabel"))
@@ -100,8 +102,8 @@ def test_inference_pipeline_cli(dataset, task_type):
 
     config = InferenceConfig(
         data_path=ires.files("tests.assets.data").joinpath("clinc_subset.json"),
-        source_dir=dump_dir,
-        output_path=dump_dir,
+        source_dir=logging_config.dirpath,
+        output_path=logging_config.dump_dir,
         log_level="CRITICAL",
     )
     inference_pipeline(config)

--- a/tests/pipeline/test_inference.py
+++ b/tests/pipeline/test_inference.py
@@ -4,12 +4,14 @@ from typing import Literal
 
 import pytest
 
+from autointent.configs.inference_cli import InferenceConfig
 from autointent.configs.optimization_cli import (
     EmbedderConfig,
     LoggingConfig,
     VectorIndexConfig,
 )
 from autointent.pipeline.inference import InferencePipeline
+from autointent.pipeline.inference.cli_endpoint import main as inference_pipeline
 from autointent.pipeline.optimization import PipelineOptimizer
 from autointent.pipeline.optimization.utils import load_config
 from tests.conftest import setup_environment
@@ -77,3 +79,29 @@ def test_inference_context(dataset, task_type):
         assert prediction.shape == (2,)
 
     context.dump()
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    ["multiclass", "multilabel", "description"],
+)
+def test_inference_pipeline_cli(dataset, task_type):
+    db_dir, dump_dir, logs_dir = setup_environment()
+    search_space = get_search_space(task_type)
+
+    pipeline_optimizer = PipelineOptimizer.from_dict_config(search_space)
+
+    pipeline_optimizer.set_config(LoggingConfig(dirpath=Path(logs_dir).resolve(), dump_dir=dump_dir, dump_modules=True))
+    pipeline_optimizer.set_config(VectorIndexConfig(db_dir=Path(db_dir).resolve(), device="cuda", save_db=True))
+    pipeline_optimizer.set_config(EmbedderConfig(batch_size=16, max_length=32))
+    context = pipeline_optimizer.optimize_from_dataset(dataset, force_multilabel=(task_type == "multilabel"))
+
+    context.dump()
+
+    config = InferenceConfig(
+        data_path=ires.files("tests.assets.data").joinpath("clinc_subset.json"),
+        source_dir=dump_dir,
+        output_path=dump_dir,
+        log_level="CRITICAL",
+    )
+    inference_pipeline(config)

--- a/tests/pipeline/test_inference.py
+++ b/tests/pipeline/test_inference.py
@@ -39,7 +39,7 @@ def test_inference_config(dataset, task_type):
     pipeline_optimizer = PipelineOptimizer.from_dict_config(search_space)
 
     pipeline_optimizer.set_config(LoggingConfig(dirpath=Path(logs_dir).resolve(), dump_modules=True))
-    pipeline_optimizer.set_config(VectorIndexConfig(db_dir=Path(db_dir).resolve(), device="cuda", save_db=True))
+    pipeline_optimizer.set_config(VectorIndexConfig(db_dir=Path(db_dir).resolve(), device="cpu", save_db=True))
     pipeline_optimizer.set_config(EmbedderConfig(batch_size=16, max_length=32))
 
     context = pipeline_optimizer.optimize_from_dataset(dataset, force_multilabel=(task_type == "multilabel"))
@@ -66,7 +66,7 @@ def test_inference_context(dataset, task_type):
     pipeline_optimizer = PipelineOptimizer.from_dict_config(search_space)
 
     pipeline_optimizer.set_config(LoggingConfig(dirpath=Path(logs_dir).resolve(), dump_modules=True))
-    pipeline_optimizer.set_config(VectorIndexConfig(db_dir=Path(db_dir).resolve(), device="cuda", save_db=True))
+    pipeline_optimizer.set_config(VectorIndexConfig(db_dir=Path(db_dir).resolve(), device="cpu", save_db=True))
     pipeline_optimizer.set_config(EmbedderConfig(batch_size=16, max_length=32))
 
     context = pipeline_optimizer.optimize_from_dataset(dataset, force_multilabel=(task_type == "multilabel"))

--- a/tests/pipeline/test_inference.py
+++ b/tests/pipeline/test_inference.py
@@ -1,0 +1,79 @@
+import importlib.resources as ires
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from autointent.configs.optimization_cli import (
+    EmbedderConfig,
+    LoggingConfig,
+    VectorIndexConfig,
+)
+from autointent.pipeline.inference import InferencePipeline
+from autointent.pipeline.optimization import PipelineOptimizer
+from autointent.pipeline.optimization.utils import load_config
+from tests.conftest import setup_environment
+
+TaskType = Literal["multiclass", "multilabel", "description"]
+
+
+def get_search_space_path(task_type: TaskType):
+    return ires.files("tests.assets.configs").joinpath(f"{task_type}.yaml")
+
+
+def get_search_space(task_type: TaskType):
+    path = get_search_space_path(task_type)
+    return load_config(str(path), multilabel=task_type == "multilabel")
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    ["multiclass", "multilabel", "description"],
+)
+def test_inference_config(dataset, task_type):
+    db_dir, dump_dir, logs_dir = setup_environment()
+    search_space = get_search_space(task_type)
+
+    pipeline_optimizer = PipelineOptimizer.from_dict_config(search_space)
+
+    pipeline_optimizer.set_config(LoggingConfig(dirpath=Path(logs_dir).resolve(), dump_modules=True))
+    pipeline_optimizer.set_config(VectorIndexConfig(db_dir=Path(db_dir).resolve(), device="cuda", save_db=True))
+    pipeline_optimizer.set_config(EmbedderConfig(batch_size=16, max_length=32))
+
+    context = pipeline_optimizer.optimize_from_dataset(dataset, force_multilabel=(task_type == "multilabel"))
+    inference_config = context.optimization_info.get_inference_nodes_config()
+
+    inference_pipeline = InferencePipeline.from_config(inference_config)
+    prediction = inference_pipeline.predict(["123", "hello world"])
+    if task_type == "multilabel":
+        assert prediction.shape == (2, len(dataset.intents))
+    else:
+        assert prediction.shape == (2,)
+
+    context.dump()
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    ["multiclass", "multilabel", "description"],
+)
+def test_inference_context(dataset, task_type):
+    db_dir, dump_dir, logs_dir = setup_environment()
+    search_space = get_search_space(task_type)
+
+    pipeline_optimizer = PipelineOptimizer.from_dict_config(search_space)
+
+    pipeline_optimizer.set_config(LoggingConfig(dirpath=Path(logs_dir).resolve(), dump_modules=True))
+    pipeline_optimizer.set_config(VectorIndexConfig(db_dir=Path(db_dir).resolve(), device="cuda", save_db=True))
+    pipeline_optimizer.set_config(EmbedderConfig(batch_size=16, max_length=32))
+
+    context = pipeline_optimizer.optimize_from_dataset(dataset, force_multilabel=(task_type == "multilabel"))
+    inference_pipeline = InferencePipeline.from_context(context)
+    prediction = inference_pipeline.predict(["123", "hello world"])
+
+    if task_type == "multilabel":
+        assert prediction.shape == (2, len(dataset.intents))
+    else:
+        assert prediction.shape == (2,)
+
+    context.dump()


### PR DESCRIPTION
Тесты для InferencePipeline

Текущие проблемы:

- тест `tests/pipeline/test_inference.py` проходит только если добавить в конфиги `tests/assets/configs/` для модуля скоринга `model_name`:
```yaml
nodes:
  - node_type: retrieval
    metric: retrieval_hit_rate
    search_space:
      - module_type: vector_db
        k: [10]
        model_name:
          - sentence-transformers/all-MiniLM-L6-v2
  - node_type: scoring
    metric: scoring_roc_auc
    search_space:
      - module_type: description
        temperature: [1.0, 0.5, 0.1, 0.05]
        model_name:
          - sentence-transformers/all-MiniLM-L6-v2
  - node_type: prediction
    metric: prediction_accuracy
    search_space:
      - module_type: argmax
```
иначе выдает ошибку:
```
TypeError: KNNScorer.__init__() missing 1 required positional argument: 'model_name'
```
Это нормальное поведение? Стоит ли менять конфиг? Как я поняла, model_name это энкодер из векторной базы и он должен подставляться автоматически исходя из лучшего энкодера