### PR TITLE
Fix and improve working with datasets

### DIFF
--- a/autointent/_dataset/_dataset.py
+++ b/autointent/_dataset/_dataset.py
@@ -78,18 +78,6 @@ class Dataset(dict[str, HFDataset]):
         return len(self.intents)
 
     @classmethod
-    def from_json(cls, filepath: str | Path) -> "Dataset":
-        """
-        Load a dataset from a JSON file.
-
-        :param filepath: Path to the JSON file.
-        :return: Initialized Dataset object.
-        """
-        from ._reader import JsonReader
-
-        return JsonReader().read(filepath)
-
-    @classmethod
     def from_dict(cls, mapping: dict[str, Any]) -> "Dataset":
         """
         Load a dataset from a dictionary mapping.
@@ -100,6 +88,18 @@ class Dataset(dict[str, HFDataset]):
         from ._reader import DictReader
 
         return DictReader().read(mapping)
+
+    @classmethod
+    def from_json(cls, filepath: str | Path) -> "Dataset":
+        """
+        Load a dataset from a JSON file.
+
+        :param filepath: Path to the JSON file.
+        :return: Initialized Dataset object.
+        """
+        from ._reader import JsonReader
+
+        return JsonReader().read(filepath)
 
     @classmethod
     def from_hub(cls, repo_id: str) -> "Dataset":

--- a/autointent/_dataset/_dataset.py
+++ b/autointent/_dataset/_dataset.py
@@ -74,7 +74,7 @@ class Dataset(dict[str, HFDataset]):
 
         :return: Number of classes.
         """
-        return self.get_n_classes(Split.TRAIN)
+        return len(self.intents)
 
     @classmethod
     def from_json(cls, filepath: str | Path) -> "Dataset":

--- a/autointent/_dataset/_validation.py
+++ b/autointent/_dataset/_validation.py
@@ -1,6 +1,6 @@
 """File with definitions of DatasetReader and DatasetValidator."""
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from autointent.schemas import Intent, Sample
 
@@ -28,6 +28,8 @@ class DatasetReader(BaseModel):
     test: list[Sample] = []
     intents: list[Intent] = []
 
+    model_config = ConfigDict(extra="forbid")
+
     @model_validator(mode="after")
     def validate_dataset(self) -> "DatasetReader":
         """
@@ -54,7 +56,13 @@ class DatasetReader(BaseModel):
                 raise ValueError(message)
 
         splits = [
-            self.train, self.train_0, self.train_1, self.validation, self.validation_0, self.validation_1, self.test,
+            self.train,
+            self.train_0,
+            self.train_1,
+            self.validation,
+            self.validation_0,
+            self.validation_1,
+            self.test,
         ]
         splits = [split for split in splits if split]
 
@@ -66,10 +74,7 @@ class DatasetReader(BaseModel):
             )
             raise ValueError(message)
         if not n_classes[0]:
-            message = (
-                "Number of classes is zero or undefined. "
-                "Ensure at least one class is present in the splits."
-            )
+            message = "Number of classes is zero or undefined. " "Ensure at least one class is present in the splits."
             raise ValueError(message)
 
         self._validate_intents(n_classes[0])

--- a/autointent/_dataset/_validation.py
+++ b/autointent/_dataset/_validation.py
@@ -9,13 +9,22 @@ class DatasetReader(BaseModel):
     """
     A class to represent a dataset reader for handling training, validation, and test data.
 
-    :param train: List of samples for training.
+    :param train: List of samples for training. Defaults to an empty list.
+    :param train_0: List of samples for scoring module training. Defaults to an empty list.
+    :param train_1: List of samples for decision module training. Defaults to an empty list.
     :param validation: List of samples for validation. Defaults to an empty list.
+    :param validation_0: List of samples for scoring module validation. Defaults to an empty list.
+    :param validation_1: List of samples for decision module validation. Defaults to an empty list.
     :param test: List of samples for testing. Defaults to an empty list.
     :param intents: List of intents associated with the dataset.
     """
 
     train: list[Sample]
+    train_0: list[Sample] = []
+    train_1: list[Sample] = []
+    validation: list[Sample] = []
+    validation_0: list[Sample] = []
+    validation_1: list[Sample] = []
     test: list[Sample] = []
     intents: list[Intent] = []
 
@@ -27,6 +36,23 @@ class DatasetReader(BaseModel):
         :raises ValueError: If intents or samples are not properly validated.
         :return: The validated DatasetReader instance.
         """
+        if self.train and (self.train_0 or self.train_1):
+            message = "If `train` is provided, `train_0` and `train_1` should be empty."
+            raise ValueError(message)
+        if not self.train and (not self.train_0 or not self.train_1):
+            message = "Both `train_0` and `train_1` must be provided if `train` is empty."
+            raise ValueError(message)
+
+        if self.validation and (self.validation_0 or self.validation_1):
+            message = "If `validation` is provided, `validation_0` and `validation_1` should be empty."
+            raise ValueError(message)
+        if not self.validation:
+            message = "Either both `validation_0` and `validation_1` must be provided, or neither of them."
+            if not self.validation_0 and self.validation_1:
+                raise ValueError(message)
+            if self.validation_0 and not self.validation_1:
+                raise ValueError(message)
+
         self._validate_intents()
         for split in [self.train, self.test]:
             self._validate_split(split)

--- a/autointent/_dataset/_validation.py
+++ b/autointent/_dataset/_validation.py
@@ -19,7 +19,7 @@ class DatasetReader(BaseModel):
     :param intents: List of intents associated with the dataset.
     """
 
-    train: list[Sample]
+    train: list[Sample] = []
     train_0: list[Sample] = []
     train_1: list[Sample] = []
     validation: list[Sample] = []
@@ -53,19 +53,58 @@ class DatasetReader(BaseModel):
             if self.validation_0 and not self.validation_1:
                 raise ValueError(message)
 
-        self._validate_intents()
-        for split in [self.train, self.test]:
+        splits = [
+            self.train, self.train_0, self.train_1, self.validation, self.validation_0, self.validation_1, self.test,
+        ]
+        splits = [split for split in splits if split]
+
+        n_classes = [self._get_n_classes(split) for split in splits]
+        if len(set(n_classes)) != 1:
+            message = (
+                f"Mismatch in number of classes across splits. Found class counts: {n_classes}. "
+                "Ensure all splits have the same number of classes."
+            )
+            raise ValueError(message)
+        if not n_classes[0]:
+            message = (
+                "Number of classes is zero or undefined. "
+                "Ensure at least one class is present in the splits."
+            )
+            raise ValueError(message)
+
+        self._validate_intents(n_classes[0])
+
+        for split in splits:
             self._validate_split(split)
         return self
 
-    def _validate_intents(self) -> "DatasetReader":
+    def _get_n_classes(self, split: list[Sample]) -> int:
+        """
+        Get the number of classes in a dataset split.
+
+        :param split: List of samples in a dataset split (train, validation, or test).
+        :return: The number of classes.
+        """
+        classes = set()
+        for sample in split:
+            match sample.label:
+                case int():
+                    classes.add(sample.label)
+                case list():
+                    for label in sample.label:
+                        classes.add(label)
+        return len(classes)
+
+    def _validate_intents(self, n_classes: int) -> "DatasetReader":
         """
         Validate the intents by checking their IDs for sequential order.
 
+        :param n_classes: The number of classes in the dataset.
         :raises ValueError: If intent IDs are not sequential starting from 0.
         :return: The DatasetReader instance after validation.
         """
         if not self.intents:
+            self.intents = [Intent(id=idx) for idx in range(n_classes)]
             return self
         self.intents = sorted(self.intents, key=lambda intent: intent.id)
         intent_ids = [intent.id for intent in self.intents]
@@ -85,8 +124,6 @@ class DatasetReader(BaseModel):
         :raises ValueError: If a sample references an invalid or non-existent intent ID.
         :return: The DatasetReader instance after validation.
         """
-        if not split or not self.intents:
-            return self
         intent_ids = {intent.id for intent in self.intents}
         for sample in split:
             message = (

--- a/autointent/context/_context.py
+++ b/autointent/context/_context.py
@@ -137,9 +137,7 @@ class Context:
         # self._logger.info(make_report(optimization_results, nodes=nodes))
 
         # dump train and test data splits
-        dataset_path = logs_dir / "dataset.json"
-        with dataset_path.open("w") as file:
-            json.dump(self.data_handler.dump(), file, indent=4, ensure_ascii=False)
+        self.data_handler.dump(logs_dir / "dataset.json")
 
         self._logger.info("logs and other assets are saved to %s", logs_dir)
 

--- a/autointent/context/_utils.py
+++ b/autointent/context/_utils.py
@@ -56,7 +56,7 @@ def load_data(filepath: str | Path) -> Dataset:
     if filepath == "default-multiclass":
         return Dataset.from_hub("AutoIntent/clinc150_subset")
     if filepath == "default-multilabel":
-        return Dataset.from_hub("AutoIntent/clinc150_subset").to_multilabel().encode_labels()
+        return Dataset.from_hub("AutoIntent/clinc150_subset").to_multilabel()
     if not Path(filepath).exists():
         return Dataset.from_hub(str(filepath))
     return Dataset.from_json(filepath)

--- a/autointent/context/data_handler/_data_handler.py
+++ b/autointent/context/data_handler/_data_handler.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any, TypedDict, cast
 
+from datasets import concatenate_datasets
 from transformers import set_seed
 
 from autointent import Dataset
@@ -192,50 +193,27 @@ class DataHandler:
         return self.dataset.dump()
 
     def _split(self, random_seed: int) -> None:
+        has_validation_split = any(split.startswith(Split.VALIDATION) for split in self.dataset)
+        has_test_split = any(split.startswith(Split.TEST) for split in self.dataset)
+
+        if Split.TRAIN in self.dataset:
+            self._split_train(random_seed)
+
         if Split.TEST not in self.dataset:
-            self.dataset[Split.TRAIN], self.dataset[Split.TEST] = split_dataset(
-                self.dataset,
-                split=Split.TRAIN,
-                test_size=0.2,
-                random_seed=random_seed,
-            )
+            test_size = 0.1 if has_validation_split else 0.2
+            self._split_test(test_size, random_seed)
 
-        self.dataset[f"{Split.TRAIN}_0"], self.dataset[f"{Split.TRAIN}_1"] = split_dataset(
-            self.dataset,
-            split=Split.TRAIN,
-            test_size=0.5,
-            random_seed=random_seed,
-        )
-        self.dataset.pop(Split.TRAIN)
-
-        for idx in range(2):
-            self.dataset[f"{Split.TRAIN}_{idx}"], self.dataset[f"{Split.VALIDATION}_{idx}"] = split_dataset(
-                self.dataset,
-                split=f"{Split.TRAIN}_{idx}",
-                test_size=0.2,
-                random_seed=random_seed,
-            )
+        if not has_validation_split:
+            if not has_test_split:
+                self._split_validation_from_test(random_seed)
+                self._split_validation(random_seed)
+            else:
+                self._split_validation_from_train(random_seed)
+        elif Split.VALIDATION in self.dataset:
+            self._split_validation(random_seed)
 
         if self.has_oos_samples():
-            self.dataset[f"{Split.OOS}_0"], self.dataset[f"{Split.OOS}_1"] = (
-                self.dataset[Split.OOS]
-                .train_test_split(
-                    test_size=0.2,
-                    shuffle=True,
-                    seed=random_seed,
-                )
-                .values()
-            )
-            self.dataset[f"{Split.OOS}_1"], self.dataset[f"{Split.OOS}_2"] = (
-                self.dataset[f"{Split.OOS}_1"]
-                .train_test_split(
-                    test_size=0.5,
-                    shuffle=True,
-                    seed=random_seed,
-                )
-                .values()
-            )
-            self.dataset.pop(Split.OOS)
+            self._split_oos(random_seed)
 
         for split in self.dataset:
             if split.startswith(Split.OOS):
@@ -247,3 +225,78 @@ class DataHandler:
                     f"({n_classes_split} != {self.n_classes})"
                 )
                 raise ValueError(message)
+
+    def _split_train(self, random_seed: int) -> None:
+        self.dataset[f"{Split.TRAIN}_0"], self.dataset[f"{Split.TRAIN}_1"] = split_dataset(
+            self.dataset,
+            split=Split.TRAIN,
+            test_size=0.5,
+            random_seed=random_seed,
+        )
+        self.dataset.pop(Split.TRAIN)
+
+    def _split_validation(self, random_seed: int) -> None:
+        self.dataset[f"{Split.VALIDATION}_0"], self.dataset[f"{Split.VALIDATION}_1"] = split_dataset(
+            self.dataset,
+            split=Split.VALIDATION,
+            test_size=0.5,
+            random_seed=random_seed,
+        )
+        self.dataset.pop(Split.VALIDATION)
+
+    def _split_validation_from_test(self, random_seed: int) -> None:
+        self.dataset[Split.TEST], self.dataset[Split.VALIDATION] = split_dataset(
+            self.dataset,
+            split=Split.TEST,
+            test_size=0.5,
+            random_seed=random_seed,
+        )
+
+    def _split_validation_from_train(self, random_seed: int) -> None:
+        for idx in range(2):
+            self.dataset[f"{Split.TRAIN}_{idx}"], self.dataset[f"{Split.VALIDATION}_{idx}"] = split_dataset(
+                self.dataset,
+                split=f"{Split.TRAIN}_{idx}",
+                test_size=0.2,
+                random_seed=random_seed,
+            )
+
+    def _split_test(self, test_size: float, random_seed: int) -> None:
+        self.dataset[f"{Split.TRAIN}_0"], self.dataset[f"{Split.TEST}_0"] = split_dataset(
+            self.dataset,
+            split=f"{Split.TRAIN}_0",
+            test_size=test_size,
+            random_seed=random_seed,
+        )
+        self.dataset[f"{Split.TRAIN}_1"], self.dataset[f"{Split.TEST}_1"] = split_dataset(
+            self.dataset,
+            split=f"{Split.TRAIN}_1",
+            test_size=test_size,
+            random_seed=random_seed,
+        )
+        self.dataset[Split.TEST] = concatenate_datasets(
+            [self.dataset[f"{Split.TEST}_0"], self.dataset[f"{Split.TEST}_1"]],
+        )
+        self.dataset.pop(f"{Split.TEST}_0")
+        self.dataset.pop(f"{Split.TEST}_1")
+
+    def _split_oos(self, random_seed: int) -> None:
+        self.dataset[f"{Split.OOS}_0"], self.dataset[f"{Split.OOS}_1"] = (
+            self.dataset[Split.OOS]
+            .train_test_split(
+                test_size=0.2,
+                shuffle=True,
+                seed=random_seed,
+            )
+            .values()
+        )
+        self.dataset[f"{Split.OOS}_1"], self.dataset[f"{Split.OOS}_2"] = (
+            self.dataset[f"{Split.OOS}_1"]
+            .train_test_split(
+                test_size=0.5,
+                shuffle=True,
+                seed=random_seed,
+            )
+            .values()
+        )
+        self.dataset.pop(Split.OOS)

--- a/autointent/context/data_handler/_data_handler.py
+++ b/autointent/context/data_handler/_data_handler.py
@@ -1,7 +1,8 @@
 """Data Handler file."""
 
 import logging
-from typing import Any, TypedDict, cast
+from pathlib import Path
+from typing import TypedDict, cast
 
 from datasets import concatenate_datasets
 from transformers import set_seed
@@ -182,13 +183,13 @@ class DataHandler:
         """
         return any(split.startswith(Split.OOS) for split in self.dataset)
 
-    def dump(self) -> dict[str, list[dict[str, Any]]]:
+    def dump(self, filepath: str | Path) -> None:
         """
-        Dump the dataset splits.
+        Save the dataset splits and intents to a JSON file.
 
-        :return: Dataset dump.
+        :param filepath: The path to the file where the JSON data will be saved.
         """
-        return self.dataset.dump()
+        self.dataset.to_json(filepath)
 
     def _split(self, random_seed: int) -> None:
         has_validation_split = any(split.startswith(Split.VALIDATION) for split in self.dataset)

--- a/autointent/context/data_handler/_data_handler.py
+++ b/autointent/context/data_handler/_data_handler.py
@@ -46,8 +46,6 @@ class DataHandler:
         self.dataset = dataset
         if force_multilabel:
             self.dataset = self.dataset.to_multilabel()
-        if self.dataset.multilabel:
-            self.dataset = self.dataset.encode_labels()
 
         self.n_classes = self.dataset.n_classes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ ignore = [
 "__init__.py" = ["F401", "D104"]
 "autointent/__init__.py" = ["I001"]
 "tests/*.py" = ["S", "PLR2004", "ERA", "D", "ANN", "SLF"]
+"tests/context/datahandler/test_data_handler.py" = ["PT011"]
 "autointent/modules/*" = ["ARG002", "ARG003"]  # unused argument
 "docs/*" = ["INP001", "A001", "D"]
 "*/utils.py" = ["D104", "D100"]

--- a/tests/context/datahandler/test_data_handler.py
+++ b/tests/context/datahandler/test_data_handler.py
@@ -91,26 +91,6 @@ def test_data_handler_multilabel_mode(sample_multilabel_data):
     assert handler.test_labels() == [[1, 0], [0, 1]]
 
 
-def test_dump_method(sample_multiclass_data):
-    handler = DataHandler(dataset=Dataset.from_dict(sample_multiclass_data), random_seed=42)
-
-    dump = handler.dump()
-
-    for split in ["train_0", "validation_0", "train_1", "validation_1", "test"]:
-        assert split in dump
-
-    assert dump["train_0"] == [
-        {"utterance": "hello", "label": 0},
-        {"utterance": "bye", "label": 1},
-        {"utterance": "hi", "label": 0},
-        {"utterance": "take care", "label": 1},
-    ]
-    assert dump["test"] == [
-        {"utterance": "greetings", "label": 0},
-        {"utterance": "farewell", "label": 1},
-    ]
-
-
 @pytest.mark.skip("All data validations will be refactored later")
 def test_error_handling(
     sample_multiclass_intent_records,

--- a/tests/context/datahandler/test_data_handler.py
+++ b/tests/context/datahandler/test_data_handler.py
@@ -1,5 +1,7 @@
 import pytest
 
+from pydantic import ValidationError
+
 from autointent import Dataset
 from autointent.context.data_handler import DataHandler
 from autointent.schemas import Sample
@@ -147,5 +149,8 @@ def test_dataset_validation():
         Dataset.from_dict({"train": [{"utterance": "Hello!"}]})
     with pytest.raises(ValueError):
         Dataset.from_dict(
-            {"train": mock_split, "test": [{"utterance": "Hello!", "label": 1}, {"utterance": "Hello!", "label": 0}]},
+            {"train": mock_split, "test": [{"utterance": "Hello!", "label": 0}, {"utterance": "Hello!", "label": 1}]},
         )
+
+    with pytest.raises(ValidationError):
+        Dataset.from_dict({"train": mock_split, "oos": mock_split})

--- a/tests/context/datahandler/test_stratificaiton.py
+++ b/tests/context/datahandler/test_stratificaiton.py
@@ -18,7 +18,7 @@ def test_train_test_split(dataset):
 
 
 def test_multilabel_train_test_split(dataset):
-    dataset = dataset.to_multilabel().encode_labels()
+    dataset = dataset.to_multilabel()
     dataset[Split.TRAIN], dataset[Split.TEST] = split_dataset(
         dataset,
         split=Split.TRAIN,


### PR DESCRIPTION
- Добавлена возможность вручную указать сплиты `train_0`, `train_1`, `validation_0` и `validation_1`
- Добавлены методы для экспорта `Dataset` (`to_dict`, `to_json`)
- Если `intents` не были переданы на этапе создания датасета, то они задаются автоматически
- `n_classes` у `Dataset` теперь зависят от количества `intents`
- `encode_labels` стал приватным + теперь нет необходимости вызывать этот метод на стороне пользователя