### PR TITLE
Vector index and embeddings caching

### DIFF
--- a/autointent/_embedder.py
+++ b/autointent/_embedder.py
@@ -60,7 +60,7 @@ class Embedder:
         device: str = "cpu",
         batch_size: int = 32,
         max_length: int | None = None,
-        use_cache: bool = False,
+        use_cache: bool = True,
     ) -> None:
         """
         Initialize the Embedder.
@@ -69,7 +69,7 @@ class Embedder:
         :param device: Device to run the model on (e.g., "cpu", "cuda").
         :param batch_size: Batch size for embedding calculations.
         :param max_length: Maximum sequence length for the embedding model.
-        :param embedder_use_cache: Flag indicating whether to cache intermediate embeddings.
+        :param use_cache: Flag indicating whether to cache intermediate embeddings.
         """
         self.model_name = model_name
         self.device = device

--- a/autointent/configs/_optimization_cli.py
+++ b/autointent/configs/_optimization_cli.py
@@ -109,7 +109,7 @@ class EmbedderConfig:
     """Batch size for the embedder"""
     max_length: int | None = None
     """Max length for the embedder. If None, the max length will be taken from model config"""
-    use_cache: bool = False
+    use_cache: bool = True
     """Flag indicating whether to cache embeddings for reuse, improving performance in repeated operations."""
     device: str = "cpu"
     """Device to use for the vector index. Can be 'cpu', 'cuda', 'cuda:0', 'mps', etc."""

--- a/autointent/context/vector_index_client/_vector_index.py
+++ b/autointent/context/vector_index_client/_vector_index.py
@@ -31,7 +31,7 @@ class VectorIndex:
         embedder_device: str,
         embedder_batch_size: int = 32,
         embedder_max_length: int | None = None,
-        embedder_use_cache: bool = False,
+        embedder_use_cache: bool = True,
     ) -> None:
         """
         Initialize the vector index.

--- a/autointent/context/vector_index_client/_vector_index.py
+++ b/autointent/context/vector_index_client/_vector_index.py
@@ -121,7 +121,7 @@ class VectorIndex:
             msg = "`embedding` should be a 2D array of shape (n_queries, dim_size)"
             raise ValueError(msg)
 
-        cos_sim, indices = self.index.search(embedding, k)
+        cos_sim, indices = self.index.search(embedding, k)  # TODO add caching similar to Embedder.embed() caching
         distances = 1 - cos_sim
 
         results = []

--- a/autointent/context/vector_index_client/_vector_index_client.py
+++ b/autointent/context/vector_index_client/_vector_index_client.py
@@ -32,7 +32,7 @@ class VectorIndexClient:
         db_dir: str | Path | None,
         embedder_batch_size: int = 32,
         embedder_max_length: int | None = None,
-        embedder_use_cache: bool = False,
+        embedder_use_cache: bool = True,
     ) -> None:
         """
         Initialize the VectorIndexClient.

--- a/autointent/modules/embedding/_retrieval.py
+++ b/autointent/modules/embedding/_retrieval.py
@@ -72,7 +72,7 @@ class RetrievalEmbedding(EmbeddingModule):
         embedder_device: str = "cpu",
         batch_size: int = 32,
         max_length: int | None = None,
-        embedder_use_cache: bool = False,
+        embedder_use_cache: bool = True,
     ) -> None:
         """
         Initialize the RetrievalEmbedding.

--- a/autointent/modules/scoring/_description/description.py
+++ b/autointent/modules/scoring/_description/description.py
@@ -10,7 +10,6 @@ from numpy.typing import NDArray
 from sklearn.metrics.pairwise import cosine_similarity
 
 from autointent import Context, Embedder
-from autointent.context.vector_index_client import VectorIndex, VectorIndexClient
 from autointent.custom_types import LabelType
 from autointent.modules.abc import ScoringModule
 
@@ -18,7 +17,6 @@ from autointent.modules.abc import ScoringModule
 class DescriptionScorerDumpMetadata(TypedDict):
     """Metadata for dumping the state of a DescriptionScorer."""
 
-    db_dir: str
     n_classes: int
     multilabel: bool
     batch_size: int
@@ -36,18 +34,13 @@ class DescriptionScorer(ScoringModule):
     :ivar embedder: The embedder used to generate embeddings for utterances and descriptions.
     :ivar precomputed_embeddings: Flag indicating whether precomputed embeddings are used.
     :ivar embedding_model_subdir: Directory for storing the embedder's model files.
-    :ivar _vector_index: Internal vector index used when embeddings are precomputed.
-    :ivar db_dir: Directory path where the vector database is stored.
     :ivar name: Name of the scorer, defaults to "description".
 
     """
 
     weights_file_name: str = "description_vectors.npy"
     embedder: Embedder
-    precomputed_embeddings: bool = False
     embedding_model_subdir: str = "embedding_model"
-    _vector_index: VectorIndex
-    db_dir: str
     name = "description"
 
     def __init__(
@@ -93,19 +86,13 @@ class DescriptionScorer(ScoringModule):
         """
         if embedder_name is None:
             embedder_name = context.optimization_info.get_best_embedder()
-            precomputed_embeddings = True
-        else:
-            precomputed_embeddings = context.vector_index_client.exists(embedder_name)
 
-        instance = cls(
+        return cls(
             temperature=temperature,
             embedder_device=context.get_device(),
             embedder_name=embedder_name,
             embedder_use_cache=context.get_use_cache(),
         )
-        instance.precomputed_embeddings = precomputed_embeddings
-        instance.db_dir = str(context.get_db_dir())
-        return instance
 
     def get_embedder_name(self) -> str:
         """
@@ -136,31 +123,6 @@ class DescriptionScorer(ScoringModule):
             self.n_classes = len(set(labels))
             self.multilabel = False
 
-        if self.precomputed_embeddings:
-            # this happens only when LinearScorer is within Pipeline opimization after RetrievalNode optimization
-            vector_index_client = VectorIndexClient(
-                self.embedder_device,
-                self.db_dir,
-                self.batch_size,
-                self.max_length,
-                self.embedder_use_cache,
-            )
-            vector_index = vector_index_client.get_index(self.embedder_name)
-            features = vector_index.get_all_embeddings()
-            if len(features) != len(utterances):
-                msg = "Vector index mismatches provided utterances"
-                raise ValueError(msg)
-            embedder = vector_index.embedder
-        else:
-            embedder = Embedder(
-                device=self.embedder_device,
-                model_name=self.embedder_name,
-                batch_size=self.batch_size,
-                max_length=self.max_length,
-                use_cache=self.embedder_use_cache,
-            )
-            features = embedder.embed(utterances)
-
         if any(description is None for description in descriptions):
             error_text = (
                 "Some intent descriptions (label_description) are missing (None). "
@@ -168,7 +130,15 @@ class DescriptionScorer(ScoringModule):
             )
             raise ValueError(error_text)
 
-        self.description_vectors = embedder.embed([desc for desc in descriptions if desc])
+        embedder = Embedder(
+            device=self.embedder_device,
+            model_name=self.embedder_name,
+            batch_size=self.batch_size,
+            max_length=self.max_length,
+            use_cache=self.embedder_use_cache,
+        )
+
+        self.description_vectors = embedder.embed(descriptions)
         self.embedder = embedder
 
     def predict(self, utterances: list[str]) -> NDArray[np.float64]:
@@ -198,7 +168,6 @@ class DescriptionScorer(ScoringModule):
         :param path: Path to the directory where assets will be dumped.
         """
         self.metadata = DescriptionScorerDumpMetadata(
-            db_dir=str(self.db_dir),
             n_classes=self.n_classes,
             multilabel=self.multilabel,
             batch_size=self.batch_size,

--- a/autointent/modules/scoring/_description/description.py
+++ b/autointent/modules/scoring/_description/description.py
@@ -50,7 +50,7 @@ class DescriptionScorer(ScoringModule):
         embedder_device: str = "cpu",
         batch_size: int = 32,
         max_length: int | None = None,
-        embedder_use_cache: bool = False,
+        embedder_use_cache: bool = True,
     ) -> None:
         """
         Initialize the DescriptionScorer.

--- a/autointent/modules/scoring/_description/description.py
+++ b/autointent/modules/scoring/_description/description.py
@@ -19,8 +19,8 @@ class DescriptionScorerDumpMetadata(TypedDict):
 
     n_classes: int
     multilabel: bool
-    batch_size: int
-    max_length: int | None
+    embedder_batch_size: int
+    embedder_max_length: int | None
 
 
 class DescriptionScorer(ScoringModule):
@@ -48,8 +48,8 @@ class DescriptionScorer(ScoringModule):
         embedder_name: str,
         temperature: float = 1.0,
         embedder_device: str = "cpu",
-        batch_size: int = 32,
-        max_length: int | None = None,
+        embedder_batch_size: int = 32,
+        embedder_max_length: int | None = None,
         embedder_use_cache: bool = True,
     ) -> None:
         """
@@ -58,15 +58,15 @@ class DescriptionScorer(ScoringModule):
         :param embedder_name: Name of the embedder model.
         :param temperature: Temperature parameter for scaling logits, defaults to 1.0.
         :param embedder_device: Device to run the embedder on, e.g., "cpu" or "cuda".
-        :param batch_size: Batch size for embedding generation, defaults to 32.
-        :param max_length: Maximum sequence length for embedding, defaults to None.
+        :param embedder_batch_size: Batch size for embedding generation, defaults to 32.
+        :param embedder_max_length: Maximum sequence length for embedding, defaults to None.
         :param embedder_use_cache: Flag indicating whether to cache intermediate embeddings.
         """
         self.temperature = temperature
         self.embedder_device = embedder_device
         self.embedder_name = embedder_name
-        self.batch_size = batch_size
-        self.max_length = max_length
+        self.embedder_batch_size = embedder_batch_size
+        self.embedder_max_length = embedder_max_length
         self.embedder_use_cache = embedder_use_cache
 
     @classmethod
@@ -92,6 +92,8 @@ class DescriptionScorer(ScoringModule):
             embedder_device=context.get_device(),
             embedder_name=embedder_name,
             embedder_use_cache=context.get_use_cache(),
+            embedder_batch_size=context.get_batch_size(),
+            embedder_max_length=context.get_max_length(),
         )
 
     def get_embedder_name(self) -> str:
@@ -133,8 +135,8 @@ class DescriptionScorer(ScoringModule):
         embedder = Embedder(
             device=self.embedder_device,
             model_name=self.embedder_name,
-            batch_size=self.batch_size,
-            max_length=self.max_length,
+            batch_size=self.embedder_batch_size,
+            max_length=self.embedder_max_length,
             use_cache=self.embedder_use_cache,
         )
 
@@ -170,8 +172,8 @@ class DescriptionScorer(ScoringModule):
         self.metadata = DescriptionScorerDumpMetadata(
             n_classes=self.n_classes,
             multilabel=self.multilabel,
-            batch_size=self.batch_size,
-            max_length=self.max_length,
+            embedder_batch_size=self.embedder_batch_size,
+            embedder_max_length=self.embedder_max_length,
         )
 
         dump_dir = Path(path)
@@ -201,7 +203,7 @@ class DescriptionScorer(ScoringModule):
         self.embedder = Embedder(
             device=self.embedder_device,
             model_name=embedder_dir,
-            batch_size=self.metadata["batch_size"],
-            max_length=self.metadata["max_length"],
+            batch_size=self.metadata["embedder_batch_size"],
+            max_length=self.metadata["embedder_max_length"],
             use_cache=self.embedder_use_cache,
         )

--- a/autointent/modules/scoring/_description/description.py
+++ b/autointent/modules/scoring/_description/description.py
@@ -32,7 +32,6 @@ class DescriptionScorer(ScoringModule):
 
     :ivar weights_file_name: Filename for saving the description vectors (`description_vectors.npy`).
     :ivar embedder: The embedder used to generate embeddings for utterances and descriptions.
-    :ivar precomputed_embeddings: Flag indicating whether precomputed embeddings are used.
     :ivar embedding_model_subdir: Directory for storing the embedder's model files.
     :ivar name: Name of the scorer, defaults to "description".
 

--- a/autointent/modules/scoring/_dnnc/dnnc.py
+++ b/autointent/modules/scoring/_dnnc/dnnc.py
@@ -164,11 +164,8 @@ class DNNCScorer(ScoringModule):
         """
         if embedder_name is None:
             embedder_name = context.optimization_info.get_best_embedder()
-            prebuilt_index = True
-        else:
-            prebuilt_index = context.vector_index_client.exists(embedder_name)
 
-        instance = cls(
+        return cls(
             cross_encoder_name=cross_encoder_name,
             embedder_name=embedder_name,
             k=k,
@@ -179,8 +176,6 @@ class DNNCScorer(ScoringModule):
             max_length=context.get_max_length(),
             embedder_use_cache=context.get_use_cache(),
         )
-        instance.prebuilt_index = prebuilt_index
-        return instance
 
     def fit(self, utterances: list[str], labels: list[LabelType]) -> None:
         """
@@ -195,15 +190,7 @@ class DNNCScorer(ScoringModule):
         self.model = CrossEncoder(self.cross_encoder_name, trust_remote_code=True, device=self.device)
 
         vector_index_client = VectorIndexClient(self.device, self.db_dir, embedder_use_cache=self.embedder_use_cache)
-
-        if self.prebuilt_index:
-            # this happens only when LinearScorer is within Pipeline opimization after RetrievalNode optimization
-            self.vector_index = vector_index_client.get_index(self.embedder_name)
-            if len(utterances) != len(self.vector_index.texts):
-                msg = "Vector index mismatches provided utterances"
-                raise ValueError(msg)
-        else:
-            self.vector_index = vector_index_client.create_index(self.embedder_name, utterances, labels)
+        self.vector_index = vector_index_client.create_index(self.embedder_name, utterances, labels)
 
         if self.train_head:
             model = CrossEncoderWithLogreg(self.model)

--- a/autointent/modules/scoring/_dnnc/dnnc.py
+++ b/autointent/modules/scoring/_dnnc/dnnc.py
@@ -51,7 +51,6 @@ class DNNCScorer(ScoringModule):
 
     :ivar crossencoder_subdir: Subdirectory for storing the cross-encoder model (`crossencoder`).
     :ivar model: The model used for scoring, which could be a `CrossEncoder` or a `CrossEncoderWithLogreg`.
-    :ivar prebuilt_index: Flag indicating whether a prebuilt vector index is used.
     :ivar _db_dir: Path to the database directory where the vector index is stored.
     :ivar name: Name of the scorer, defaults to "dnnc".
 
@@ -95,7 +94,6 @@ class DNNCScorer(ScoringModule):
 
     crossencoder_subdir: str = "crossencoder"
     model: CrossEncoder | CrossEncoderWithLogreg
-    prebuilt_index: bool = False
 
     def __init__(
         self,

--- a/autointent/modules/scoring/_dnnc/dnnc.py
+++ b/autointent/modules/scoring/_dnnc/dnnc.py
@@ -105,7 +105,7 @@ class DNNCScorer(ScoringModule):
         train_head: bool = False,
         batch_size: int = 32,
         max_length: int | None = None,
-        embedder_use_cache: bool = False,
+        embedder_use_cache: bool = True,
     ) -> None:
         """
         Initialize the DNNCScorer.

--- a/autointent/modules/scoring/_knn/knn.py
+++ b/autointent/modules/scoring/_knn/knn.py
@@ -91,7 +91,7 @@ class KNNScorer(ScoringModule):
         embedder_device: str = "cpu",
         batch_size: int = 32,
         max_length: int | None = None,
-        embedder_use_cache: bool = False,
+        embedder_use_cache: bool = True,
     ) -> None:
         """
         Initialize the KNNScorer.

--- a/autointent/modules/scoring/_knn/knn.py
+++ b/autointent/modules/scoring/_knn/knn.py
@@ -22,15 +22,15 @@ class KNNScorerDumpMetadata(BaseMetadataDict):
     :ivar n_classes: Number of classes in the dataset.
     :ivar multilabel: Whether the task is multilabel classification.
     :ivar db_dir: Path to the database directory.
-    :ivar batch_size: Batch size used for embedding.
-    :ivar max_length: Maximum sequence length for embedding, or None if not specified.
+    :ivar embedder_batch_size: Batch size used for embedding.
+    :ivar embedder_max_length: Maximum sequence length for embedding, or None if not specified.
     """
 
     n_classes: int
     multilabel: bool
     db_dir: str
-    batch_size: int
-    max_length: int | None
+    embedder_batch_size: int
+    embedder_max_length: int | None
 
 
 class KNNScorer(ScoringModule):
@@ -80,7 +80,6 @@ class KNNScorer(ScoringModule):
     weights: WEIGHT_TYPES
     _vector_index: VectorIndex
     name = "knn"
-    max_length: int | None
 
     def __init__(
         self,
@@ -89,8 +88,8 @@ class KNNScorer(ScoringModule):
         weights: WEIGHT_TYPES = "distance",
         db_dir: str | None = None,
         embedder_device: str = "cpu",
-        batch_size: int = 32,
-        max_length: int | None = None,
+        embedder_batch_size: int = 32,
+        embedder_max_length: int | None = None,
         embedder_use_cache: bool = True,
     ) -> None:
         """
@@ -104,8 +103,8 @@ class KNNScorer(ScoringModule):
             - "closest": Only the closest neighbor of each class is weighted.
         :param db_dir: Path to the database directory, or None to use default.
         :param embedder_device: Device to run operations on, e.g., "cpu" or "cuda".
-        :param batch_size: Batch size for embedding generation, defaults to 32.
-        :param max_length: Maximum sequence length for embedding, or None for default.
+        :param embedder_batch_size: Batch size for embedding generation, defaults to 32.
+        :param embedder_max_length: Maximum sequence length for embedding, or None for default.
         :param embedder_use_cache: Flag indicating whether to cache intermediate embeddings.
         """
         self.embedder_name = embedder_name
@@ -113,8 +112,8 @@ class KNNScorer(ScoringModule):
         self.weights = weights
         self._db_dir = db_dir
         self.embedder_device = embedder_device
-        self.batch_size = batch_size
-        self.max_length = max_length
+        self.embedder_batch_size = embedder_batch_size
+        self.embedder_max_length = embedder_max_length
         self.embedder_use_cache = embedder_use_cache
 
     @property
@@ -154,8 +153,8 @@ class KNNScorer(ScoringModule):
             weights=weights,
             db_dir=str(context.get_db_dir()),
             embedder_device=context.get_device(),
-            batch_size=context.get_batch_size(),
-            max_length=context.get_max_length(),
+            embedder_batch_size=context.get_batch_size(),
+            embedder_max_length=context.get_max_length(),
             embedder_use_cache=context.get_use_cache(),
         )
 
@@ -183,7 +182,11 @@ class KNNScorer(ScoringModule):
             self.multilabel = False
 
         vector_index_client = VectorIndexClient(
-            self.embedder_device, self.db_dir, embedder_use_cache=self.embedder_use_cache
+            self.embedder_device,
+            self.db_dir,
+            embedder_use_cache=self.embedder_use_cache,
+            embedder_batch_size=self.embedder_batch_size,
+            embedder_max_length=self.embedder_max_length,
         )
         self._vector_index = vector_index_client.create_index(self.embedder_name, utterances, labels)
 
@@ -231,8 +234,8 @@ class KNNScorer(ScoringModule):
             db_dir=self.db_dir,
             n_classes=self.n_classes,
             multilabel=self.multilabel,
-            batch_size=self.batch_size,
-            max_length=self.max_length,
+            embedder_batch_size=self.embedder_batch_size,
+            embedder_max_length=self.embedder_max_length,
         )
 
     def load(self, path: str) -> None:
@@ -255,8 +258,8 @@ class KNNScorer(ScoringModule):
         vector_index_client = VectorIndexClient(
             embedder_device=self.embedder_device,
             db_dir=metadata["db_dir"],
-            embedder_batch_size=metadata["batch_size"],
-            embedder_max_length=metadata["max_length"],
+            embedder_batch_size=metadata["embedder_batch_size"],
+            embedder_max_length=metadata["embedder_max_length"],
             embedder_use_cache=self.embedder_use_cache,
         )
         self._vector_index = vector_index_client.get_index(self.embedder_name)

--- a/autointent/modules/scoring/_knn/knn.py
+++ b/autointent/modules/scoring/_knn/knn.py
@@ -43,7 +43,6 @@ class KNNScorer(ScoringModule):
     :ivar weights: Weighting strategy used for scoring.
     :ivar _vector_index: VectorIndex instance for neighbor retrieval.
     :ivar name: Name of the scorer, defaults to "knn".
-    :ivar prebuilt_index: Flag indicating if the vector index is prebuilt.
 
     Examples
     --------
@@ -81,7 +80,6 @@ class KNNScorer(ScoringModule):
     weights: WEIGHT_TYPES
     _vector_index: VectorIndex
     name = "knn"
-    prebuilt_index: bool = False
     max_length: int | None
 
     def __init__(
@@ -149,11 +147,8 @@ class KNNScorer(ScoringModule):
         """
         if embedder_name is None:
             embedder_name = context.optimization_info.get_best_embedder()
-            prebuilt_index = True
-        else:
-            prebuilt_index = context.vector_index_client.exists(embedder_name)
 
-        instance = cls(
+        return cls(
             embedder_name=embedder_name,
             k=k,
             weights=weights,
@@ -163,8 +158,6 @@ class KNNScorer(ScoringModule):
             max_length=context.get_max_length(),
             embedder_use_cache=context.get_use_cache(),
         )
-        instance.prebuilt_index = prebuilt_index
-        return instance
 
     def get_embedder_name(self) -> str:
         """
@@ -188,18 +181,11 @@ class KNNScorer(ScoringModule):
         else:
             self.n_classes = len(set(labels))
             self.multilabel = False
+
         vector_index_client = VectorIndexClient(
             self.embedder_device, self.db_dir, embedder_use_cache=self.embedder_use_cache
         )
-
-        if self.prebuilt_index:
-            # this happens only after RetrievalNode optimization
-            self._vector_index = vector_index_client.get_index(self.embedder_name)
-            if len(utterances) != len(self._vector_index.texts):
-                msg = "Vector index mismatches provided utterances"
-                raise ValueError(msg)
-        else:
-            self._vector_index = vector_index_client.create_index(self.embedder_name, utterances, labels)
+        self._vector_index = vector_index_client.create_index(self.embedder_name, utterances, labels)
 
     def predict(self, utterances: list[str]) -> npt.NDArray[Any]:
         """

--- a/autointent/modules/scoring/_knn/rerank_scorer.py
+++ b/autointent/modules/scoring/_knn/rerank_scorer.py
@@ -196,7 +196,7 @@ class RerankScorer(KNNScorer):
             utterances, knn_labels, knn_distances, knn_neighbors, strict=True
         ):
             cur_ranks = self._scorer.rank(
-                query, query_docs, top_k=self.m, batch_size=self.batch_size, activation_fct=Sigmoid()
+                query, query_docs, top_k=self.m, batch_size=self.embedder_batch_size, activation_fct=Sigmoid()
             )
 
             for dst, src in zip(

--- a/autointent/modules/scoring/_knn/rerank_scorer.py
+++ b/autointent/modules/scoring/_knn/rerank_scorer.py
@@ -111,11 +111,8 @@ class RerankScorer(KNNScorer):
         """
         if embedder_name is None:
             embedder_name = context.optimization_info.get_best_embedder()
-            prebuilt_index = True
-        else:
-            prebuilt_index = context.vector_index_client.exists(embedder_name)
 
-        instance = cls(
+        return cls(
             embedder_name=embedder_name,
             k=k,
             weights=weights,
@@ -127,9 +124,6 @@ class RerankScorer(KNNScorer):
             batch_size=context.get_batch_size(),
             max_length=context.get_max_length(),
         )
-        # TODO: needs re-thinking....
-        instance.prebuilt_index = prebuilt_index
-        return instance
 
     def fit(self, utterances: list[str], labels: list[LabelType]) -> None:
         """

--- a/autointent/modules/scoring/_knn/rerank_scorer.py
+++ b/autointent/modules/scoring/_knn/rerank_scorer.py
@@ -133,8 +133,10 @@ class RerankScorer(KNNScorer):
         :param labels: List of labels corresponding to the utterances.
         """
         self._scorer = CrossEncoder(
-            self.cross_encoder_name, device=self.embedder_device, max_length=self.embedder_max_length
-        )  # type: ignore[arg-type]
+            self.cross_encoder_name,
+            device=self.embedder_device,
+            max_length=self.embedder_max_length,  # type: ignore[arg-type]
+        )
 
         super().fit(utterances, labels)
 
@@ -176,8 +178,10 @@ class RerankScorer(KNNScorer):
         self.cross_encoder_name = metadata["cross_encoder_name"]
         self.rank_threshold_cutoff = metadata["rank_threshold_cutoff"]
         self._scorer = CrossEncoder(
-            self.cross_encoder_name, device=self.embedder_device, max_length=self.embedder_max_length
-        )  # type: ignore[arg-type]
+            self.cross_encoder_name,
+            device=self.embedder_device,
+            max_length=self.embedder_max_length,  # type: ignore[arg-type]
+        )
 
     def _predict(self, utterances: list[str]) -> tuple[npt.NDArray[Any], list[list[str]]]:
         """

--- a/autointent/modules/scoring/_knn/rerank_scorer.py
+++ b/autointent/modules/scoring/_knn/rerank_scorer.py
@@ -52,8 +52,8 @@ class RerankScorer(KNNScorer):
         rank_threshold_cutoff: int | None = None,
         db_dir: str | None = None,
         embedder_device: str = "cpu",
-        batch_size: int = 32,
-        max_length: int | None = None,
+        embedder_batch_size: int = 32,
+        embedder_max_length: int | None = None,
     ) -> None:
         """
         Initialize the RerankScorer.
@@ -69,8 +69,8 @@ class RerankScorer(KNNScorer):
         :param rank_threshold_cutoff: Rank threshold cutoff for re-ranking, or None.
         :param db_dir: Path to the database directory, or None to use default.
         :param embedder_device: Device to run operations on, e.g., "cpu" or "cuda".
-        :param batch_size: Batch size for embedding generation, defaults to 32.
-        :param max_length: Maximum sequence length for embedding, or None for default.
+        :param embedder_batch_size: Batch size for embedding generation, defaults to 32.
+        :param embedder_max_length: Maximum sequence length for embedding and cross encoder, or None for default.
         """
         super().__init__(
             embedder_name=embedder_name,
@@ -78,8 +78,8 @@ class RerankScorer(KNNScorer):
             weights=weights,
             db_dir=db_dir,
             embedder_device=embedder_device,
-            batch_size=batch_size,
-            max_length=max_length,
+            embedder_batch_size=embedder_batch_size,
+            embedder_max_length=embedder_max_length,
         )
 
         self.cross_encoder_name = cross_encoder_name
@@ -121,8 +121,8 @@ class RerankScorer(KNNScorer):
             rank_threshold_cutoff=rank_threshold_cutoff,
             db_dir=str(context.get_db_dir()),
             embedder_device=context.get_device(),
-            batch_size=context.get_batch_size(),
-            max_length=context.get_max_length(),
+            embedder_batch_size=context.get_batch_size(),
+            embedder_max_length=context.get_max_length(),
         )
 
     def fit(self, utterances: list[str], labels: list[LabelType]) -> None:
@@ -132,7 +132,9 @@ class RerankScorer(KNNScorer):
         :param utterances: List of utterances to fit the scorer.
         :param labels: List of labels corresponding to the utterances.
         """
-        self._scorer = CrossEncoder(self.cross_encoder_name, device=self.embedder_device, max_length=self.max_length)  # type: ignore[arg-type]
+        self._scorer = CrossEncoder(
+            self.cross_encoder_name, device=self.embedder_device, max_length=self.embedder_max_length
+        )  # type: ignore[arg-type]
 
         super().fit(utterances, labels)
 
@@ -173,7 +175,9 @@ class RerankScorer(KNNScorer):
         self.m = metadata["m"] if metadata["m"] else self.k
         self.cross_encoder_name = metadata["cross_encoder_name"]
         self.rank_threshold_cutoff = metadata["rank_threshold_cutoff"]
-        self._scorer = CrossEncoder(self.cross_encoder_name, device=self.embedder_device, max_length=self.max_length)  # type: ignore[arg-type]
+        self._scorer = CrossEncoder(
+            self.cross_encoder_name, device=self.embedder_device, max_length=self.embedder_max_length
+        )  # type: ignore[arg-type]
 
     def _predict(self, utterances: list[str]) -> tuple[npt.NDArray[Any], list[list[str]]]:
         """

--- a/autointent/modules/scoring/_linear.py
+++ b/autointent/modules/scoring/_linear.py
@@ -80,7 +80,7 @@ class LinearScorer(ScoringModule):
         seed: int = 0,
         batch_size: int = 32,
         max_length: int | None = None,
-        embedder_use_cache: bool = False,
+        embedder_use_cache: bool = True,
     ) -> None:
         """
         Initialize the LinearScorer.

--- a/autointent/modules/scoring/_linear.py
+++ b/autointent/modules/scoring/_linear.py
@@ -11,7 +11,6 @@ from sklearn.linear_model import LogisticRegression, LogisticRegressionCV
 from sklearn.multioutput import MultiOutputClassifier
 
 from autointent import Context, Embedder
-from autointent.context.vector_index_client import VectorIndexClient
 from autointent.custom_types import BaseMetadataDict, LabelType
 from autointent.modules.abc import ScoringModule
 
@@ -21,13 +20,13 @@ class LinearScorerDumpDict(BaseMetadataDict):
     Metadata for dumping the state of a LinearScorer.
 
     :ivar multilabel: Whether the task is multilabel classification.
-    :ivar batch_size: Batch size used for embedding.
-    :ivar max_length: Maximum sequence length for embedding, or None if not specified.
+    :ivar embedder_batch_size: Batch size used for embedding.
+    :ivar embedder_max_length: Maximum sequence length for embedding, or None if not specified.
     """
 
     multilabel: bool
-    batch_size: int
-    max_length: int | None
+    embedder_batch_size: int
+    embedder_max_length: int | None
 
 
 class LinearScorer(ScoringModule):
@@ -39,8 +38,6 @@ class LinearScorer(ScoringModule):
 
     :ivar classifier_file_name: Filename for saving the classifier to disk.
     :ivar embedding_model_subdir: Directory for saving the embedding model.
-    :ivar precomputed_embeddings: Flag indicating if embeddings are precomputed.
-    :ivar db_dir: Path to the database directory.
     :ivar name: Name of the scorer, defaults to "linear".
 
     Example
@@ -67,8 +64,6 @@ class LinearScorer(ScoringModule):
 
     classifier_file_name: str = "classifier.joblib"
     embedding_model_subdir: str = "embedding_model"
-    precomputed_embeddings: bool = False
-    db_dir: str
     name = "linear"
 
     def __init__(
@@ -78,8 +73,8 @@ class LinearScorer(ScoringModule):
         n_jobs: int | None = None,
         embedder_device: str = "cpu",
         seed: int = 0,
-        batch_size: int = 32,
-        max_length: int | None = None,
+        embedder_batch_size: int = 32,
+        embedder_max_length: int | None = None,
         embedder_use_cache: bool = True,
     ) -> None:
         """
@@ -90,8 +85,8 @@ class LinearScorer(ScoringModule):
         :param n_jobs: Number of parallel jobs for cross-validation, defaults to -1 (all CPUs).
         :param embedder_device: Device to run operations on, e.g., "cpu" or "cuda".
         :param seed: Random seed for reproducibility, defaults to 0.
-        :param batch_size: Batch size for embedding generation, defaults to 32.
-        :param max_length: Maximum sequence length for embedding, or None for default.
+        :param embedder_batch_size: Batch size for embedding generation, defaults to 32.
+        :param embedder_max_length: Maximum sequence length for embedding, or None for default.
         :param embedder_use_cache: Flag indicating whether to cache intermediate embeddings.
         """
         self.cv = cv
@@ -99,8 +94,8 @@ class LinearScorer(ScoringModule):
         self.embedder_device = embedder_device
         self.seed = seed
         self.embedder_name = embedder_name
-        self.batch_size = batch_size
-        self.max_length = max_length
+        self.embedder_batch_size = embedder_batch_size
+        self.embedder_max_length = embedder_max_length
         self.embedder_use_cache = embedder_use_cache
 
     @classmethod
@@ -118,21 +113,15 @@ class LinearScorer(ScoringModule):
         """
         if embedder_name is None:
             embedder_name = context.optimization_info.get_best_embedder()
-            precomputed_embeddings = True
-        else:
-            precomputed_embeddings = context.vector_index_client.exists(embedder_name)
 
-        instance = cls(
+        return cls(
             embedder_name=embedder_name,
             embedder_device=context.get_device(),
             seed=context.seed,
-            batch_size=context.get_batch_size(),
-            max_length=context.get_max_length(),
+            embedder_batch_size=context.get_batch_size(),
+            embedder_max_length=context.get_max_length(),
             embedder_use_cache=context.get_use_cache(),
         )
-        instance.precomputed_embeddings = precomputed_embeddings
-        instance.db_dir = str(context.get_db_dir())
-        return instance
 
     def get_embedder_name(self) -> str:
         """
@@ -156,30 +145,14 @@ class LinearScorer(ScoringModule):
         """
         self._multilabel = isinstance(labels[0], list)
 
-        if self.precomputed_embeddings:
-            # this happens only when LinearScorer is within Pipeline opimization after RetrievalNode optimization
-            vector_index_client = VectorIndexClient(
-                self.embedder_device,
-                self.db_dir,
-                self.batch_size,
-                self.max_length,
-                self.embedder_use_cache,
-            )
-            vector_index = vector_index_client.get_index(self.embedder_name)
-            features = vector_index.get_all_embeddings()
-            if len(features) != len(utterances):
-                msg = "Vector index mismatches provided utterances"
-                raise ValueError(msg)
-            embedder = vector_index.embedder
-        else:
-            embedder = Embedder(
-                device=self.embedder_device,
-                model_name=self.embedder_name,
-                batch_size=self.batch_size,
-                max_length=self.max_length,
-                use_cache=self.embedder_use_cache,
-            )
-            features = embedder.embed(utterances)
+        embedder = Embedder(
+            device=self.embedder_device,
+            model_name=self.embedder_name,
+            batch_size=self.embedder_batch_size,
+            max_length=self.embedder_max_length,
+            use_cache=self.embedder_use_cache,
+        )
+        features = embedder.embed(utterances)
 
         if self._multilabel:
             base_clf = LogisticRegression()
@@ -217,8 +190,8 @@ class LinearScorer(ScoringModule):
         """
         self.metadata = LinearScorerDumpDict(
             multilabel=self._multilabel,
-            batch_size=self.batch_size,
-            max_length=self.max_length,
+            embedder_batch_size=self.embedder_batch_size,
+            embedder_max_length=self.embedder_max_length,
         )
 
         dump_dir = Path(path)
@@ -256,7 +229,7 @@ class LinearScorer(ScoringModule):
         self._embedder = Embedder(
             device=self.embedder_device,
             model_name=embedder_dir,
-            batch_size=metadata["batch_size"],
-            max_length=metadata["max_length"],
+            batch_size=metadata["embedder_batch_size"],
+            max_length=metadata["embedder_max_length"],
             use_cache=self.embedder_use_cache,
         )

--- a/autointent/modules/scoring/_mlknn/mlknn.py
+++ b/autointent/modules/scoring/_mlknn/mlknn.py
@@ -19,14 +19,14 @@ class MLKnnScorerDumpMetadata(BaseMetadataDict):
 
     :ivar db_dir: Path to the database directory.
     :ivar n_classes: Number of classes in the dataset.
-    :ivar batch_size: Batch size used for embedding.
-    :ivar max_length: Maximum sequence length for embedding, or None if not specified.
+    :ivar embedder_batch_size: Batch size used for embedding.
+    :ivar embedder_max_length: Maximum sequence length for embedding, or None if not specified.
     """
 
     db_dir: str
     n_classes: int
-    batch_size: int
-    max_length: int | None
+    embedder_batch_size: int
+    embedder_max_length: int | None
 
 
 class ArrayToSave(TypedDict):
@@ -54,7 +54,6 @@ class MLKnnScorer(ScoringModule):
 
     :ivar arrays_filename: Filename for saving probabilities to disk.
     :ivar metadata: Metadata about the scorer's configuration.
-    :ivar prebuilt_index: Flag indicating if the vector index is prebuilt.
     :ivar name: Name of the scorer, defaults to "mlknn".
 
     Example
@@ -92,7 +91,6 @@ class MLKnnScorer(ScoringModule):
 
     arrays_filename: str = "probs.npz"
     metadata: MLKnnScorerDumpMetadata
-    prebuilt_index: bool = False
     name = "mlknn"
 
     def __init__(
@@ -103,9 +101,9 @@ class MLKnnScorer(ScoringModule):
         s: float = 1.0,
         ignore_first_neighbours: int = 0,
         embedder_device: str = "cpu",
-        batch_size: int = 32,
-        max_length: int | None = None,
-        embedder_use_cache: bool = False,
+        embedder_batch_size: int = 32,
+        embedder_max_length: int | None = None,
+        embedder_use_cache: bool = True,
     ) -> None:
         """
         Initialize the MLKnnScorer.
@@ -116,8 +114,8 @@ class MLKnnScorer(ScoringModule):
         :param s: Smoothing parameter for probability calculations, defaults to 1.0.
         :param ignore_first_neighbours: Number of closest neighbors to ignore, defaults to 0.
         :param embedder_device: Device to run operations on, e.g., "cpu" or "cuda".
-        :param batch_size: Batch size for embedding generation, defaults to 32.
-        :param max_length: Maximum sequence length for embedding, or None for default.
+        :param embedder_batch_size: Batch size for embedding generation, defaults to 32.
+        :param embedder_max_length: Maximum sequence length for embedding, or None for default.
         :param embedder_use_cache: Flag indicating whether to cache intermediate embeddings.
         """
         self.k = k
@@ -126,8 +124,8 @@ class MLKnnScorer(ScoringModule):
         self.ignore_first_neighbours = ignore_first_neighbours
         self._db_dir = db_dir
         self.embedder_device = embedder_device
-        self.batch_size = batch_size
-        self.max_length = max_length
+        self.embedder_batch_size = embedder_batch_size
+        self.embedder_max_length = embedder_max_length
         self.embedder_use_cache = embedder_use_cache
 
     @property
@@ -162,23 +160,18 @@ class MLKnnScorer(ScoringModule):
         """
         if embedder_name is None:
             embedder_name = context.optimization_info.get_best_embedder()
-            prebuilt_index = True
-        else:
-            prebuilt_index = context.vector_index_client.exists(embedder_name)
 
-        instance = cls(
+        return cls(
             k=k,
             embedder_name=embedder_name,
             s=s,
             ignore_first_neighbours=ignore_first_neighbours,
             db_dir=str(context.get_db_dir()),
             embedder_device=context.get_device(),
-            batch_size=context.get_batch_size(),
-            max_length=context.get_max_length(),
+            embedder_batch_size=context.get_batch_size(),
+            embedder_max_length=context.get_max_length(),
             embedder_use_cache=context.get_use_cache(),
         )
-        instance.prebuilt_index = prebuilt_index
-        return instance
 
     def get_embedder_name(self) -> str:
         """
@@ -204,17 +197,13 @@ class MLKnnScorer(ScoringModule):
         self.n_classes = len(labels[0])
 
         vector_index_client = VectorIndexClient(
-            self.embedder_device, self.db_dir, embedder_use_cache=self.embedder_use_cache
+            self.embedder_device,
+            self.db_dir,
+            embedder_use_cache=self.embedder_use_cache,
+            embedder_batch_size=self.embedder_batch_size,
+            embedder_max_length=self.embedder_max_length,
         )
-
-        if self.prebuilt_index:
-            # this happens only when LinearScorer is within Pipeline opimization after RetrievalNode optimization
-            self.vector_index = vector_index_client.get_index(self.embedder_name)
-            if len(utterances) != len(self.vector_index.texts):
-                msg = "Vector index mismatches provided utterances"
-                raise ValueError(msg)
-        else:
-            self.vector_index = vector_index_client.create_index(self.embedder_name, utterances, labels)
+        self.vector_index = vector_index_client.create_index(self.embedder_name, utterances, labels)
 
         self.features = (
             self.vector_index.embedder.embed(utterances)
@@ -319,8 +308,8 @@ class MLKnnScorer(ScoringModule):
         self.metadata = MLKnnScorerDumpMetadata(
             db_dir=self.db_dir,
             n_classes=self.n_classes,
-            batch_size=self.batch_size,
-            max_length=self.max_length,
+            embedder_batch_size=self.embedder_batch_size,
+            embedder_max_length=self.embedder_max_length,
         )
 
         dump_dir = Path(path)
@@ -358,8 +347,8 @@ class MLKnnScorer(ScoringModule):
         vector_index_client = VectorIndexClient(
             embedder_device=self.embedder_device,
             db_dir=self.metadata["db_dir"],
-            embedder_batch_size=self.metadata["batch_size"],
-            embedder_max_length=self.metadata["max_length"],
+            embedder_batch_size=self.metadata["embedder_batch_size"],
+            embedder_max_length=self.metadata["embedder_max_length"],
             embedder_use_cache=self.embedder_use_cache,
         )
         self.vector_index = vector_index_client.get_index(self.embedder_name)


### PR DESCRIPTION
Код модулей стал намного понятнее. Конкретно, понятнее стали методы `from_context` и `fit`.

Сам векторный индекс и запросы к нему нигде не кешируются, потому что и построение и поиск у нас происходит очень быстро (датасеты не такие большие). А эмбединги кешируются уже благодаря реализованным в `Embedder` фичам.

В будущем можно реализовать кеширование запросов к индексу (в релизе посвященном производительности)