### PR TITLE
Pin yarl below 1.24.0 until PyPI wheels are complete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,10 @@ vllm = [
 ]
 
 [tool.uv]
+override-dependencies = [
+    # yarl 1.24.0 shipped incomplete wheels on PyPI (cp310 only); remove when fixed.
+    "yarl<1.24.0",
+]
 conflicts = [
     [
         { extra = "codecarbon" },


### PR DESCRIPTION
## Summary

- Adds `tool.uv.override-dependencies` to cap `yarl` at `<1.24.0`.
- Workaround for [yarl 1.24.0](https://pypi.org/project/yarl/1.24.0/) shipping incomplete wheels on PyPI (only `cp310` at publish time), which broke `uv sync` on Python 3.11+ in CI.

## Test plan

- [x] `uv python pin 3.13 && uv sync --group test --extra sentence-transformers --extra transformers` resolves `yarl==1.23.0` and completes successfully
- [ ] CI matrix (3.10–3.14) passes on this branch

Remove the override once `yarl` 1.24.0+ has full wheels on PyPI for all supported Python versions.


Made with [Cursor](https://cursor.com)