### PR TITLE
ci: bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -26,14 +26,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Cache Hugging Face
         id: cache-hf
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
           key: docs-cache-hf
@@ -43,7 +43,7 @@ jobs:
           sudo apt install pandoc
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.10.0"
 
@@ -68,7 +68,7 @@ jobs:
           make multi-version-docs
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -58,7 +58,7 @@ jobs:
           make test-docs
 
       - name: Build documentation
-        if: ${{ github.ref == 'refs/heads/dev' }} && github.event_name != 'workflow_dispatch'
+        if: github.ref == 'refs/heads/dev' && github.event_name != 'workflow_dispatch'
         run: |
           make docs
 

--- a/.github/workflows/check-schema.yaml
+++ b/.github/workflows/check-schema.yaml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.head_ref }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         version: "0.10.0"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,11 +26,11 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache Hugging Face
         id: cache-hf
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
           # Stable key (no github.run_id): when the prewarm config and the
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install uv
         if: steps.cache-hf.outputs.cache-hit != 'true'
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.10.0"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Install pypa/build
@@ -20,7 +20,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions
         path: dist/
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/
@@ -61,13 +61,13 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/
 
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      uses: sigstore/gh-action-sigstore-python@v3.3.0
       with:
         inputs: >-
           ./dist/*.tar.gz

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # The HF cache is populated by ci.yaml's warm-cache job, which runs
     # before any reusable-test caller. We use the restore-only action
@@ -43,7 +43,7 @@ jobs:
     # duplicate caches.
     - name: Restore Hugging Face cache
       id: cache-hf
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ~/.cache/huggingface
         # Exact-match the key that the warm-cache job saved this run (same
@@ -55,7 +55,7 @@ jobs:
           ${{ runner.os }}-hf-warmed-
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         version: "0.10.0"
         enable-cache: "true"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/ruff-action@v4
+      - uses: astral-sh/ruff-action@v4.0.0
         with:
           version: "0.15.0"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,7 +4,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v2
+      - uses: actions/checkout@v6
+      - uses: astral-sh/ruff-action@v4
         with:
           version: "0.15.0"

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -4,14 +4,14 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.10.0"
 


### PR DESCRIPTION
Closes #298.

GitHub flagged `actions/cache@v4`, `actions/checkout@v4`, and `astral-sh/setup-uv@v6` as Node-20-deprecated (forced to Node 24 on **2026-06-16**, removed **2026-09-16**). While in there, bumped every action we use to its current Node 24 release and fixed an adjacent lint warning on `build-docs.yaml`.

## Bumps

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/cache` (+ `/restore`) | v4 | v5 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `astral-sh/setup-uv` | v6 | v7 |
| `astral-sh/ruff-action` | v2 | v4.0.0 |
| `peaceiris/actions-gh-pages` | v3 | v4 |
| `sigstore/gh-action-sigstore-python` | v3.0.0 | v3.3.0 |
| `pypa/gh-action-pypi-publish` | release/v1 | (unchanged — floating, already Node 24) |

## Notes

- `astral-sh/setup-uv@v8` and `astral-sh/ruff-action@v4` dropped floating major/minor tags as supply-chain hardening — you can only pin a full version or SHA. Staying on `setup-uv@v7` (still has the floating tag, still Node 24). For `ruff-action` there's no v3 Node 24 release, so we pin `@v4.0.0`.
- `download-artifact@v5`'s breaking path change only affects ID-based downloads; `release.yaml` uses `name:`, so it's unaffected.
- `actions/cache@v5` requires runner ≥ 2.327.1, fine for GitHub-hosted.

## Adjacent fix

`build-docs.yaml` had a pre-existing always-truthy `if:` on the "Build documentation" step (`${{ ... }}` only wrapped the first comparison, so the rest became literal text appended to the substituted string). This caused `make docs` to run on every event instead of only dev pushes. One-line fix: drop the inner `${{ }}` since `if:` is already expression context.

## Test plan

- [x] CI green on the action bumps (lint, typing, schema, all test matrices)
- [x] Warm-cache job restores HF cache correctly with `cache@v5`
- [x] Docs build still passes
- [x] No more workflow syntax warning on `build-docs.yaml:61`