### PR TITLE
fix(llm-scorer): persist generator_config across dump/load roundtrip

### DIFF
--- a/src/autointent/modules/scoring/_description/llm_encoder.py
+++ b/src/autointent/modules/scoring/_description/llm_encoder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from functools import partial
 from pathlib import Path
@@ -27,6 +28,8 @@ if TYPE_CHECKING:
     from autointent.configs import CrossEncoderConfig, EmbedderConfig
 
 logger = logging.getLogger(__name__)
+
+GENERATOR_CONFIG_FILENAME = "generator_config.json"
 
 
 class IntentCategorization(BaseModel):
@@ -288,7 +291,18 @@ class LLMDescriptionScorer(BaseDescriptionScorer):
             self._event_loop = loop
 
     def dump(self, path: str) -> None:
-        Dumper.dump(self, Path(path), exclude=[asyncio.BaseEventLoop])
+        dump_path = Path(path)
+        # Round-trip the Generator via generator_config (a dict, which the generic
+        # Dumper can't serialize). Temporarily detach _generator so the Dumper
+        # doesn't try to handle it via GeneratorDumper — load() recreates it from
+        # generator_config.
+        generator = self.__dict__.pop("_generator", None)
+        try:
+            Dumper.dump(self, dump_path, exclude=[asyncio.BaseEventLoop])
+        finally:
+            if generator is not None:
+                self._generator = generator
+        (dump_path / GENERATOR_CONFIG_FILENAME).write_text(json.dumps(self.generator_config))
 
     @classmethod
     def load(
@@ -298,5 +312,8 @@ class LLMDescriptionScorer(BaseDescriptionScorer):
         cross_encoder_config: CrossEncoderConfig | None = None,
     ) -> LLMDescriptionScorer:
         instance = super().load(path=path, embedder_config=embedder_config, cross_encoder_config=cross_encoder_config)
+        config_path = Path(path) / GENERATOR_CONFIG_FILENAME
+        instance.generator_config = json.loads(config_path.read_text()) if config_path.exists() else {}
+        instance._generator = Generator(**instance.generator_config)  # noqa: SLF001
         instance._init_event_loop()  # noqa: SLF001
         return instance

--- a/src/autointent/modules/scoring/_description/llm_encoder.py
+++ b/src/autointent/modules/scoring/_description/llm_encoder.py
@@ -292,13 +292,13 @@ class LLMDescriptionScorer(BaseDescriptionScorer):
 
     def dump(self, path: str) -> None:
         dump_path = Path(path)
-        # Round-trip the Generator via generator_config (a dict, which the generic
-        # Dumper can't serialize). Temporarily detach _generator so the Dumper
-        # doesn't try to handle it via GeneratorDumper — load() recreates it from
-        # generator_config.
+        # generator_config is handled below via a JSON sidecar; excluding `dict`
+        # from the generic Dumper silences its "cannot be dumped" error log.
+        # _generator is temporarily detached so the Dumper doesn't try to handle
+        # it via GeneratorDumper — load() recreates it from generator_config.
         generator = self.__dict__.pop("_generator", None)
         try:
-            Dumper.dump(self, dump_path, exclude=[asyncio.BaseEventLoop])
+            Dumper.dump(self, dump_path, exclude=[asyncio.BaseEventLoop, dict])
         finally:
             if generator is not None:
                 self._generator = generator

--- a/tests/modules/scoring/test_description_llm.py
+++ b/tests/modules/scoring/test_description_llm.py
@@ -41,14 +41,6 @@ def test_description_scorer_llm(dataset, multilabel, patch_llm_scorer_generator)
     assert metadata is None
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "LLMDescriptionScorer.dump silently drops generator_config (dict not in "
-        "ModuleSimpleAttributes); loaded scorer is broken. See "
-        "https://github.com/deeppavlov/AutoIntent/issues/299. Flip to xpass when fixed."
-    ),
-)
 @pytest.mark.parametrize("multilabel", [True, False])
 def test_description_scorer_llm_dump_load_roundtrip(dataset, multilabel, patch_llm_scorer_generator):
     if multilabel:

--- a/tests/pipeline/test_inference.py
+++ b/tests/pipeline/test_inference.py
@@ -18,17 +18,7 @@ def project_dir(task_type):
         "multiclass",
         "multilabel",
         "description_no_llm",
-        pytest.param(
-            "description_with_llm",
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "LLMDescriptionScorer.dump/load drops generator_config; "
-                    "loaded scorer fails on predict. See "
-                    "https://github.com/deeppavlov/AutoIntent/issues/299. Flip when fixed."
-                ),
-            ),
-        ),
+        "description_with_llm",
     ],
 )
 def test_inference_from_config(dataset, task_type, project_dir, patch_llm_scorer_generator):
@@ -76,17 +66,7 @@ def test_inference_from_config(dataset, task_type, project_dir, patch_llm_scorer
         "multiclass",
         "multilabel",
         "description_no_llm",
-        pytest.param(
-            "description_with_llm",
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "LLMDescriptionScorer.dump/load drops generator_config; "
-                    "loaded scorer fails on predict. See "
-                    "https://github.com/deeppavlov/AutoIntent/issues/299. Flip when fixed."
-                ),
-            ),
-        ),
+        "description_with_llm",
     ],
 )
 def test_inference_on_the_fly(dataset, task_type, project_dir, patch_llm_scorer_generator):

--- a/tests/pipeline/test_optimization.py
+++ b/tests/pipeline/test_optimization.py
@@ -131,17 +131,7 @@ def test_no_context_optimization(dataset, task_type, patch_llm_scorer_generator)
         "multiclass",
         "multilabel",
         "description_no_llm",
-        pytest.param(
-            "description_with_llm",
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "LLMDescriptionScorer.dump/load drops generator_config; "
-                    "loaded scorer fails on predict. See "
-                    "https://github.com/deeppavlov/AutoIntent/issues/299. Flip when fixed."
-                ),
-            ),
-        ),
+        "description_with_llm",
     ],
 )
 def test_dump_modules(dataset, task_type, patch_llm_scorer_generator):

--- a/tests/pipeline/test_presets.py
+++ b/tests/pipeline/test_presets.py
@@ -16,17 +16,7 @@ from tests.conftest import apply_test_models, setup_environment
         pytest.param("transformers-heavy", marks=pytest.mark.transformers),
         pytest.param("transformers-light", marks=pytest.mark.transformers),
         pytest.param("transformers-no-hpo", marks=pytest.mark.transformers),
-        pytest.param(
-            "zero-shot-llm",
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "LLMDescriptionScorer.dump/load drops generator_config; "
-                    "preset's dump_modules+clear_ram cycle then fails on predict. See "
-                    "https://github.com/deeppavlov/AutoIntent/issues/299. Flip when fixed."
-                ),
-            ),
-        ),
+        "zero-shot-llm",
         "zero-shot-encoders",
     ],
 )


### PR DESCRIPTION
## Summary

- `LLMDescriptionScorer.generator_config` was stored as `dict[str, Any]`, which the generic `Dumper.dump()` couldn't serialize (no registered dumper handles `dict`, and `dict` is excluded from `ModuleSimpleAttributes`). The error was logged but swallowed, so `dump()` silently dropped the attribute. The loaded scorer ended up with `generator_config = {}` and (for mocked generators) a missing `_generator`, so `predict()` raised `RuntimeError: Scorer is not initialized`.
- Override `dump()`/`load()` in `LLMDescriptionScorer` to round-trip `generator_config` via a JSON sidecar (`generator_config.json`) at the scorer's dump path, and recreate `_generator` from `generator_config` on load. `_generator` is temporarily detached during dump so the generic Dumper doesn't try to serialize it via `GeneratorDumper` — re-creating it from config on load is more robust (works for mocks too) and consistent with how the other description scorers persist their configs.
- Flip `test_description_scorer_llm_dump_load_roundtrip` out of `xfail` — it now passes for both the `multilabel=True` and `multilabel=False` parametrizations.

Fixes #299.

## Test plan

- [x] `uv run pytest tests/modules/scoring/test_description_llm.py -v` passes locally (5 passed)
- [x] `uv run ruff check` clean on touched files
- [ ] CI green