### PR TITLE
test(types): annotate tests/modules/decision (51→0 mypy errors)

### DIFF
--- a/tests/modules/decision/conftest.py
+++ b/tests/modules/decision/conftest.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
 from autointent.context.data_handler import DataHandler
 from autointent.modules.scoring import KNNScorer
+from tests._helpers import is_strict_labels
 
 if TYPE_CHECKING:
     import numpy.typing as npt
 
     from autointent import Dataset
-    from autointent.custom_types import ListOfGenericLabels, ListOfLabels
+    from autointent.custom_types import ListOfGenericLabels
 
 
 FitData = tuple["npt.NDArray[np.float64]", "ListOfGenericLabels"]
@@ -29,10 +30,12 @@ def multiclass_fit_data(dataset: Dataset) -> FitData:
     )
 
     # Labels from split 0 are guaranteed non-OOS by DataHandler invariants;
-    # cast to the narrower ListOfLabels accepted by KNNScorer.fit.
+    # narrow ListOfGenericLabels -> ListOfLabels for KNNScorer.fit via TypeGuard.
+    train_labels = data_handler.train_labels(0)
+    assert is_strict_labels(train_labels)
     scorer.fit(
         data_handler.train_utterances(0),
-        cast("ListOfLabels", data_handler.train_labels(0)),
+        train_labels,
     )
     scores = scorer.predict(data_handler.validation_utterances(1))
     labels = data_handler.validation_labels(1)
@@ -49,9 +52,11 @@ def multilabel_fit_data(dataset: Dataset) -> FitData:
         embedder_config={"n_features": 32},
     )
 
+    train_labels = data_handler.train_labels(0)
+    assert is_strict_labels(train_labels)
     scorer.fit(
         data_handler.train_utterances(0),
-        cast("ListOfLabels", data_handler.train_labels(0)),
+        train_labels,
     )
     scores = scorer.predict(data_handler.validation_utterances(1))
     labels = data_handler.validation_labels(1)

--- a/tests/modules/decision/conftest.py
+++ b/tests/modules/decision/conftest.py
@@ -1,48 +1,63 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
 import numpy as np
 import pytest
 
 from autointent.context.data_handler import DataHandler
-from autointent.modules import KNNScorer
+from autointent.modules.scoring import KNNScorer
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    from autointent import Dataset
+    from autointent.custom_types import ListOfGenericLabels, ListOfLabels
+
+
+FitData = tuple["npt.NDArray[np.float64]", "ListOfGenericLabels"]
 
 
 @pytest.fixture
-def multiclass_fit_data(dataset):
+def multiclass_fit_data(dataset: Dataset) -> FitData:
     data_handler = DataHandler(dataset)
 
-    knn_params = {
-        "k": 3,
-        "weights": "distance",
-        "embedder_config": {
-            "n_features": 32,
-        },
-    }
-    scorer = KNNScorer(**knn_params)
+    scorer = KNNScorer(
+        k=3,
+        weights="distance",
+        embedder_config={"n_features": 32},
+    )
 
-    scorer.fit(data_handler.train_utterances(0), data_handler.train_labels(0))
+    # Labels from split 0 are guaranteed non-OOS by DataHandler invariants;
+    # cast to the narrower ListOfLabels accepted by KNNScorer.fit.
+    scorer.fit(
+        data_handler.train_utterances(0),
+        cast("ListOfLabels", data_handler.train_labels(0)),
+    )
     scores = scorer.predict(data_handler.validation_utterances(1))
     labels = data_handler.validation_labels(1)
     return scores, labels
 
 
 @pytest.fixture
-def multilabel_fit_data(dataset):
+def multilabel_fit_data(dataset: Dataset) -> FitData:
     data_handler = DataHandler(dataset.to_multilabel())
 
-    knn_params = {
-        "k": 3,
-        "weights": "distance",
-        "embedder_config": {
-            "n_features": 32,
-        },
-    }
-    scorer = KNNScorer(**knn_params)
+    scorer = KNNScorer(
+        k=3,
+        weights="distance",
+        embedder_config={"n_features": 32},
+    )
 
-    scorer.fit(data_handler.train_utterances(0), data_handler.train_labels(0))
+    scorer.fit(
+        data_handler.train_utterances(0),
+        cast("ListOfLabels", data_handler.train_labels(0)),
+    )
     scores = scorer.predict(data_handler.validation_utterances(1))
     labels = data_handler.validation_labels(1)
     return scores, labels
 
 
 @pytest.fixture
-def scores():
+def scores() -> npt.NDArray[np.float64]:
     return np.array([[0.05, 0.9, 0, 0.05], [0.8, 0, 0.1, 0.1], [0, 0.2, 0.7, 0.1]])

--- a/tests/modules/decision/test_adaptive.py
+++ b/tests/modules/decision/test_adaptive.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
 from autointent.exceptions import MismatchNumClassesError, WrongClassificationError
-from autointent.modules import AdaptiveDecision
+from autointent.modules.decision import AdaptiveDecision
 from tests.conftest import setup_environment
 
+if TYPE_CHECKING:
+    from tests.modules.decision.conftest import FitData
 
-def test_multilabel(multilabel_fit_data):
+
+def test_multilabel(multilabel_fit_data: FitData) -> None:
     predictor = AdaptiveDecision()
     predictor.fit(*multilabel_fit_data)
     scores = np.array([[0.2, 0.9, 0, 0], [0.8, 0, 0.6, 0], [0, 0.4, 0.7, 0]])
@@ -16,7 +23,7 @@ def test_multilabel(multilabel_fit_data):
     np.testing.assert_array_equal(predictions, desired)
 
 
-def test_fails_on_wrong_n_classes_predict(multilabel_fit_data):
+def test_fails_on_wrong_n_classes_predict(multilabel_fit_data: FitData) -> None:
     predictor = AdaptiveDecision()
     predictor.fit(*multilabel_fit_data)
     scores = np.array([[0.1, 0.9], [0.8, 0.2], [0.3, 0.7]])
@@ -24,22 +31,22 @@ def test_fails_on_wrong_n_classes_predict(multilabel_fit_data):
         predictor.predict(scores)
 
 
-def test_fails_on_wrong_clf_problem(multiclass_fit_data):
+def test_fails_on_wrong_clf_problem(multiclass_fit_data: FitData) -> None:
     predictor = AdaptiveDecision()
     with pytest.raises(WrongClassificationError):
         predictor.fit(*multiclass_fit_data)
 
 
-def test_dump_load(multilabel_fit_data):
+def test_dump_load(multilabel_fit_data: FitData) -> None:
     predictor = AdaptiveDecision()
     predictor.fit(*multilabel_fit_data)
     preds = predictor.predict(multilabel_fit_data[0])
 
     path = setup_environment() / "adaptive_module"
-    predictor.dump(path)
+    predictor.dump(str(path))
     del predictor
 
-    predictor = AdaptiveDecision.load(path)
+    predictor = AdaptiveDecision.load(str(path))
 
     assert hasattr(predictor, "_r")
     assert predictor._r is not None

--- a/tests/modules/decision/test_argmax.py
+++ b/tests/modules/decision/test_argmax.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import numpy as np
 import pytest
 
@@ -5,15 +9,20 @@ from autointent.exceptions import MismatchNumClassesError, WrongClassificationEr
 from autointent.modules.decision import ArgmaxDecision
 from tests.conftest import setup_environment
 
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
-def test_multiclass(multiclass_fit_data, scores):
+    from tests.modules.decision.conftest import FitData
+
+
+def test_multiclass(multiclass_fit_data: FitData, scores: npt.NDArray[Any]) -> None:
     predictor = ArgmaxDecision()
     predictor.fit(*multiclass_fit_data)
     predictions = predictor.predict(scores)
     np.testing.assert_array_equal(predictions, np.array([1, 0, 2]))
 
 
-def test_fails_on_wrong_n_classes(multiclass_fit_data):
+def test_fails_on_wrong_n_classes(multiclass_fit_data: FitData) -> None:
     predictor = ArgmaxDecision()
     predictor.fit(*multiclass_fit_data)
     scores = np.array([[0.1, 0.9], [0.8, 0.2], [0.3, 0.7]])
@@ -21,22 +30,22 @@ def test_fails_on_wrong_n_classes(multiclass_fit_data):
         predictor.predict(scores)
 
 
-def test_fails_on_wrong_clf_problem(multilabel_fit_data):
+def test_fails_on_wrong_clf_problem(multilabel_fit_data: FitData) -> None:
     predictor = ArgmaxDecision()
     with pytest.raises(WrongClassificationError):
         predictor.fit(*multilabel_fit_data)
 
 
-def test_dump_load(multiclass_fit_data):
+def test_dump_load(multiclass_fit_data: FitData) -> None:
     predictor = ArgmaxDecision()
     predictor.fit(*multiclass_fit_data)
     predictions = predictor.predict(multiclass_fit_data[0])
 
     path = setup_environment() / "argmax_module"
-    predictor.dump(path)
+    predictor.dump(str(path))
     del predictor
 
-    predictor = ArgmaxDecision.load(path)
+    predictor = ArgmaxDecision.load(str(path))
     new_predictions = predictor.predict(multiclass_fit_data[0])
 
     assert all(p == n for p, n in zip(predictions, new_predictions, strict=True))

--- a/tests/modules/decision/test_jinoos.py
+++ b/tests/modules/decision/test_jinoos.py
@@ -6,14 +6,16 @@ import numpy as np
 import pytest
 
 from autointent.exceptions import MismatchNumClassesError, WrongClassificationError
-from autointent.modules import JinoosDecision
+from autointent.modules.decision import JinoosDecision
 from tests.conftest import setup_environment
 
 if TYPE_CHECKING:
     import numpy.typing as npt
 
+    from tests.modules.decision.conftest import FitData
 
-def detect_oos(scores: npt.NDArray[Any], labels: npt.NDArray[Any], thresh: float):
+
+def detect_oos(scores: npt.NDArray[Any], labels: npt.NDArray[Any], thresh: float) -> npt.NDArray[Any]:
     """
     `labels`: labels without oos detection
     """
@@ -23,7 +25,7 @@ def detect_oos(scores: npt.NDArray[Any], labels: npt.NDArray[Any], thresh: float
     return labels
 
 
-def test_predict_returns_correct_indices(multiclass_fit_data, scores):
+def test_predict_returns_correct_indices(multiclass_fit_data: FitData, scores: npt.NDArray[Any]) -> None:
     predictor = JinoosDecision()
     predictor.fit(*multiclass_fit_data)
     # inference
@@ -33,7 +35,7 @@ def test_predict_returns_correct_indices(multiclass_fit_data, scores):
     np.testing.assert_array_equal(predictions, desired)
 
 
-def test_fails_on_wrong_n_classes(multiclass_fit_data):
+def test_fails_on_wrong_n_classes(multiclass_fit_data: FitData) -> None:
     predictor = JinoosDecision()
     predictor.fit(*multiclass_fit_data)
     scores = np.array([[0.1, 0.9], [0.8, 0.2], [0.3, 0.7]])
@@ -41,22 +43,22 @@ def test_fails_on_wrong_n_classes(multiclass_fit_data):
         predictor.predict(scores)
 
 
-def test_fails_on_wrong_clf_problem(multilabel_fit_data):
+def test_fails_on_wrong_clf_problem(multilabel_fit_data: FitData) -> None:
     predictor = JinoosDecision()
     with pytest.raises(WrongClassificationError):
         predictor.fit(*multilabel_fit_data)
 
 
-def test_dump_load(multiclass_fit_data):
+def test_dump_load(multiclass_fit_data: FitData) -> None:
     predictor = JinoosDecision()
     predictor.fit(*multiclass_fit_data)
     predictions = predictor.predict(multiclass_fit_data[0])
 
     path = setup_environment() / "jinoos_module"
-    predictor.dump(path)
+    predictor.dump(str(path))
     del predictor
 
-    predictor = JinoosDecision.load(path)
+    predictor = JinoosDecision.load(str(path))
 
     assert hasattr(predictor, "_thresh")
     assert predictor._thresh is not None

--- a/tests/modules/decision/test_threshold.py
+++ b/tests/modules/decision/test_threshold.py
@@ -1,8 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import numpy as np
 import pytest
 
 from autointent.exceptions import MismatchNumClassesError
-from autointent.modules import ThresholdDecision
+from autointent.modules.decision import ThresholdDecision
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import numpy.typing as npt
+
+    from autointent.custom_types import ListOfGenericLabels
+    from tests.modules.decision.conftest import FitData
 
 
 @pytest.mark.parametrize(
@@ -18,8 +30,14 @@ from autointent.modules import ThresholdDecision
         ("multilabel_fit_data", [0.5, 0.5, 0.8, 0.5], [[0, 1, 0, 0], [1, 0, 0, 0], None]),
     ],
 )
-def test_predict(fit_fixture, threshold, expected, request, scores):
-    fit_data = request.getfixturevalue(fit_fixture)
+def test_predict(
+    fit_fixture: str,
+    threshold: float | list[float],
+    expected: ListOfGenericLabels,
+    request: pytest.FixtureRequest,
+    scores: npt.NDArray[Any],
+) -> None:
+    fit_data: FitData = request.getfixturevalue(fit_fixture)
 
     predictor = ThresholdDecision(threshold)
     predictor.fit(*fit_data)
@@ -27,7 +45,7 @@ def test_predict(fit_fixture, threshold, expected, request, scores):
     assert predictions == expected
 
 
-def test_fails_on_wrong_n_classes_predict(multiclass_fit_data):
+def test_fails_on_wrong_n_classes_predict(multiclass_fit_data: FitData) -> None:
     predictor = ThresholdDecision(thresh=0.5)
     predictor.fit(*multiclass_fit_data)
     scores = np.array([[0.1, 0.9], [0.8, 0.2], [0.3, 0.7]])
@@ -35,23 +53,23 @@ def test_fails_on_wrong_n_classes_predict(multiclass_fit_data):
         predictor.predict(scores)
 
 
-def test_fails_on_wrong_n_classes_fit(multiclass_fit_data):
+def test_fails_on_wrong_n_classes_fit(multiclass_fit_data: FitData) -> None:
     predictor = ThresholdDecision(thresh=[0.5])
     with pytest.raises(MismatchNumClassesError):
         predictor.fit(*multiclass_fit_data)
 
 
 @pytest.mark.parametrize("fit_fixture", ["multiclass_fit_data", "multilabel_fit_data"])
-def test_dump_load(fit_fixture, request, tmp_path):
-    fit_data = request.getfixturevalue(fit_fixture)
+def test_dump_load(fit_fixture: str, request: pytest.FixtureRequest, tmp_path: Path) -> None:
+    fit_data: FitData = request.getfixturevalue(fit_fixture)
     predictor = ThresholdDecision(thresh=0.3)
     predictor.fit(*fit_data)
     predictions = predictor.predict(fit_data[0])
 
-    predictor.dump(tmp_path)
+    predictor.dump(str(tmp_path))
     del predictor
 
-    predictor = ThresholdDecision.load(tmp_path)
+    predictor = ThresholdDecision.load(str(tmp_path))
 
     assert hasattr(predictor, "thresh")
     assert predictor.thresh is not None

--- a/tests/modules/decision/test_tunable.py
+++ b/tests/modules/decision/test_tunable.py
@@ -1,8 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import numpy as np
 import pytest
 
 from autointent.exceptions import MismatchNumClassesError
-from autointent.modules import TunableDecision
+from autointent.modules.decision import TunableDecision
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import numpy.typing as npt
+
+    from autointent.custom_types import ListOfGenericLabels
+    from tests.modules.decision.conftest import FitData
 
 
 @pytest.mark.parametrize(
@@ -20,8 +32,13 @@ from autointent.modules import TunableDecision
         ),
     ],
 )
-def test_predict_scenarios(request, fixture_name, scores, desired):
-    fit_data = request.getfixturevalue(fixture_name)
+def test_predict_scenarios(
+    request: pytest.FixtureRequest,
+    fixture_name: str,
+    scores: npt.NDArray[Any],
+    desired: ListOfGenericLabels,
+) -> None:
+    fit_data: FitData = request.getfixturevalue(fixture_name)
 
     predictor = TunableDecision()
     predictor.fit(*fit_data)
@@ -30,7 +47,7 @@ def test_predict_scenarios(request, fixture_name, scores, desired):
     assert predictions == desired
 
 
-def test_fails_on_wrong_n_classes_predict(multiclass_fit_data):
+def test_fails_on_wrong_n_classes_predict(multiclass_fit_data: FitData) -> None:
     predictor = TunableDecision()
     predictor.fit(*multiclass_fit_data)
     scores = np.array([[0.1, 0.9], [0.8, 0.2], [0.3, 0.7]])
@@ -39,16 +56,16 @@ def test_fails_on_wrong_n_classes_predict(multiclass_fit_data):
 
 
 @pytest.mark.parametrize("fit_fixture", ["multiclass_fit_data", "multilabel_fit_data"])
-def test_dump_load(fit_fixture, request, tmp_path):
-    fit_data = request.getfixturevalue(fit_fixture)
+def test_dump_load(fit_fixture: str, request: pytest.FixtureRequest, tmp_path: Path) -> None:
+    fit_data: FitData = request.getfixturevalue(fit_fixture)
     predictor = TunableDecision()
     predictor.fit(*fit_data)
     predictions = predictor.predict(fit_data[0])
 
-    predictor.dump(tmp_path)
+    predictor.dump(str(tmp_path))
     del predictor
 
-    predictor = TunableDecision.load(tmp_path)
+    predictor = TunableDecision.load(str(tmp_path))
     assert hasattr(predictor, "thresh")
     assert predictor.thresh is not None
     assert isinstance(predictor.thresh, np.ndarray)

--- a/tests/modules/decision/test_utils.py
+++ b/tests/modules/decision/test_utils.py
@@ -1,11 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import numpy as np
 import pytest
 
 from autointent.modules.decision._utils import apply_tags
 from autointent.schemas import Tag
 
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
-def sample_data():
+
+SampleTuple = tuple["npt.NDArray[Any]", "npt.NDArray[Any]", list[Tag], "npt.NDArray[Any]"]
+
+
+def sample_data() -> SampleTuple:
     labels = np.array([[1, 1, 0], [0, 1, 1]])
     scores = np.array([[0.9, 0.8, 0.1], [0.1, 0.8, 0.7]])
     tags = [Tag(name="mutual_exclusive", intent_ids=[0, 1])]
@@ -13,7 +23,7 @@ def sample_data():
     return labels, scores, tags, expected_labels
 
 
-def no_conflict_data():
+def no_conflict_data() -> SampleTuple:
     labels = np.array([[1, 0, 0], [0, 1, 0]])
     scores = np.array([[0.9, 0.2, 0.1], [0.1, 0.8, 0.3]])
     tags = [Tag(name="mutual_exclusive", intent_ids=[0, 1])]
@@ -21,7 +31,7 @@ def no_conflict_data():
     return labels, scores, tags, expected_labels
 
 
-def multiple_tags_data():
+def multiple_tags_data() -> SampleTuple:
     labels = np.array([[1, 1, 1, 0], [1, 0, 1, 1]])
     scores = np.array([[0.9, 0.8, 0.7, 0.6], [0.95, 0.85, 0.9, 0.8]])
     tags = [Tag(name="tag1", intent_ids=[0, 1]), Tag(name="tag2", intent_ids=[2, 3])]
@@ -83,6 +93,11 @@ def multiple_tags_data():
         ),
     ],
 )
-def test_apply_tags(labels, scores, tags, expected_labels):
+def test_apply_tags(
+    labels: npt.NDArray[Any],
+    scores: npt.NDArray[Any],
+    tags: list[Tag],
+    expected_labels: npt.NDArray[Any],
+) -> None:
     adjusted_labels = apply_tags(labels, scores, tags)
     np.testing.assert_array_equal(adjusted_labels, expected_labels)


### PR DESCRIPTION
Phase B subagent B2 diff for strict-mypy-on-tests. See docs/superpowers/specs/2026-06-07-mypy-on-tests-design.md. CI on this PR is the verification surface — pytest + typing run on GitHub Actions, not locally.