### PR TITLE
test(types): annotate tests/data (78→0 mypy errors)

### DIFF
--- a/tests/data/test_check_split_readiness.py
+++ b/tests/data/test_check_split_readiness.py
@@ -12,7 +12,7 @@ from autointent.custom_types import Split
 
 
 @pytest.fixture
-def dataset_enough_samples():
+def dataset_enough_samples() -> Dataset:
     """Multiclass dataset with ≥2 samples per class (no OOS). Ready for stratification."""
     return Dataset.from_dict(
         {
@@ -42,7 +42,7 @@ def dataset_enough_samples():
 
 
 @pytest.fixture
-def dataset_three_classes_two_each():
+def dataset_three_classes_two_each() -> Dataset:
     """3 classes, 2 samples each (no OOS). Useful for split-size feasibility tests."""
     return Dataset.from_dict(
         {
@@ -64,7 +64,7 @@ def dataset_three_classes_two_each():
 
 
 @pytest.fixture
-def dataset_underpopulated():
+def dataset_underpopulated() -> Dataset:
     """Multiclass dataset with one class having only 1 sample. Not ready for stratification."""
     return Dataset.from_dict(
         {
@@ -86,7 +86,7 @@ def dataset_underpopulated():
 
 
 @pytest.fixture
-def dataset_two_classes_barely_enough():
+def dataset_two_classes_barely_enough() -> Dataset:
     """Two classes with exactly 2 samples each. Ready for default min_samples_per_class=2."""
     return Dataset.from_dict(
         {
@@ -108,7 +108,7 @@ def dataset_two_classes_barely_enough():
     )
 
 
-def test_check_split_readiness_ready_when_enough_samples(dataset_enough_samples):
+def test_check_split_readiness_ready_when_enough_samples(dataset_enough_samples: Dataset) -> None:
     """When every class has ≥ min_samples_per_class, result is ready."""
     result = check_split_readiness(
         dataset_enough_samples,
@@ -123,7 +123,7 @@ def test_check_split_readiness_ready_when_enough_samples(dataset_enough_samples)
     assert result.reason is None
 
 
-def test_check_split_readiness_not_ready_underpopulated(dataset_underpopulated):
+def test_check_split_readiness_not_ready_underpopulated(dataset_underpopulated: Dataset) -> None:
     """When at least one class has fewer than min samples, result is not ready."""
     result = check_split_readiness(
         dataset_underpopulated,
@@ -142,7 +142,7 @@ def test_check_split_readiness_not_ready_underpopulated(dataset_underpopulated):
     assert "1 (need 2)" in result.reason
 
 
-def test_check_split_readiness_missing_split(dataset_enough_samples):
+def test_check_split_readiness_missing_split(dataset_enough_samples: Dataset) -> None:
     """When split is not in dataset, result is not ready with reason."""
     result = check_split_readiness(
         dataset_enough_samples,
@@ -151,10 +151,11 @@ def test_check_split_readiness_missing_split(dataset_enough_samples):
     )
     assert result.ready is False
     assert result.underpopulated_classes == []
+    assert result.reason is not None
     assert "nonexistent_split" in result.reason
 
 
-def test_check_split_readiness_oos_allow_none(dataset_unsplitted):
+def test_check_split_readiness_oos_allow_none(dataset_unsplitted: Dataset) -> None:
     """When dataset has OOS and allow_oos_in_train is None, result is not ready."""
     with pytest.raises(ValueError, match="allow_oos_in_train"):
         check_split_readiness(
@@ -165,7 +166,7 @@ def test_check_split_readiness_oos_allow_none(dataset_unsplitted):
         )
 
 
-def test_check_split_readiness_oos_allow_false_enough_in_domain(dataset_unsplitted):
+def test_check_split_readiness_oos_allow_false_enough_in_domain(dataset_unsplitted: Dataset) -> None:
     """With OOS and allow_oos_in_train=False, in-domain classes are checked; clinc subset has enough."""
     result = check_split_readiness(
         dataset_unsplitted,
@@ -178,7 +179,7 @@ def test_check_split_readiness_oos_allow_false_enough_in_domain(dataset_unsplitt
     assert result.reason is None
 
 
-def test_check_split_readiness_multiclass_too_small_test_split(dataset_three_classes_two_each):
+def test_check_split_readiness_multiclass_too_small_test_split(dataset_three_classes_two_each: Dataset) -> None:
     """Even with >=2/class, stratification can fail if test split can't include all classes."""
     result = check_split_readiness(
         dataset_three_classes_two_each,
@@ -192,7 +193,7 @@ def test_check_split_readiness_multiclass_too_small_test_split(dataset_three_cla
     assert "too few test samples" in result.reason
 
 
-def test_check_split_readiness_multiclass_too_small_train_split(dataset_three_classes_two_each):
+def test_check_split_readiness_multiclass_too_small_train_split(dataset_three_classes_two_each: Dataset) -> None:
     """Even with >=2/class, stratification can fail if train split can't include all classes."""
     result = check_split_readiness(
         dataset_three_classes_two_each,
@@ -206,7 +207,7 @@ def test_check_split_readiness_multiclass_too_small_train_split(dataset_three_cl
     assert "too few train samples" in result.reason
 
 
-def test_check_split_readiness_min_samples_per_class_param(dataset_two_classes_barely_enough):
+def test_check_split_readiness_min_samples_per_class_param(dataset_two_classes_barely_enough: Dataset) -> None:
     """Custom min_samples_per_class is respected."""
     result = check_split_readiness(
         dataset_two_classes_barely_enough,
@@ -227,7 +228,7 @@ def test_check_split_readiness_min_samples_per_class_param(dataset_two_classes_b
     assert result_strict.min_samples_per_class_required == 3
 
 
-def test_check_split_readiness_multilabel_returns_ready():
+def test_check_split_readiness_multilabel_returns_ready() -> None:
     """Multilabel datasets are checked by per-label positive counts."""
     dataset = Dataset.from_dict(
         {
@@ -257,7 +258,7 @@ def test_check_split_readiness_multilabel_returns_ready():
     assert result.reason is not None
 
 
-def test_check_split_readiness_marks_declared_but_unseen_intent_as_underpopulated():
+def test_check_split_readiness_marks_declared_but_unseen_intent_as_underpopulated() -> None:
     """Intents with 0 samples should be flagged so callers can filter them out."""
     dataset = Dataset.from_dict(
         {
@@ -287,7 +288,7 @@ def test_check_split_readiness_marks_declared_but_unseen_intent_as_underpopulate
     assert result.reason is not None
 
 
-def test_check_split_readiness_multilabel_oos_allow_true_checks_oos_label():
+def test_check_split_readiness_multilabel_oos_allow_true_checks_oos_label() -> None:
     """Multilabel + OOS + allow_oos_in_train=True should not crash and should include OOS label."""
     dataset = Dataset.from_dict(
         {
@@ -317,7 +318,7 @@ def test_check_split_readiness_multilabel_oos_allow_true_checks_oos_label():
     assert result.reason is not None
 
 
-def test_check_split_readiness_multilabel_oos_allow_true_ready_when_oos_sufficient():
+def test_check_split_readiness_multilabel_oos_allow_true_ready_when_oos_sufficient() -> None:
     """When OOS count meets minimum, multilabel readiness can be true."""
     dataset = Dataset.from_dict(
         {
@@ -347,7 +348,7 @@ def test_check_split_readiness_multilabel_oos_allow_true_ready_when_oos_sufficie
     assert result.reason is None
 
 
-def test_split_dataset_multilabel_oos_allow_true_does_not_raise():
+def test_split_dataset_multilabel_oos_allow_true_does_not_raise() -> None:
     """Sanity-check: split_dataset supports multilabel+OOS when allow_oos_in_train=True."""
     dataset = Dataset.from_dict(
         {
@@ -378,7 +379,7 @@ def test_split_dataset_multilabel_oos_allow_true_does_not_raise():
     assert len(test) > 0
 
 
-def test_check_split_readiness_consistent_with_split_dataset(dataset_enough_samples):
+def test_check_split_readiness_consistent_with_split_dataset(dataset_enough_samples: Dataset) -> None:
     """When check_split_readiness says ready, split_dataset does not raise."""
     result = check_split_readiness(
         dataset_enough_samples,
@@ -400,7 +401,7 @@ def test_check_split_readiness_consistent_with_split_dataset(dataset_enough_samp
     assert len(test) > 0
 
 
-def test_check_split_readiness_underpopulated_implies_split_raises(dataset_underpopulated):
+def test_check_split_readiness_underpopulated_implies_split_raises(dataset_underpopulated: Dataset) -> None:
     """When check_split_readiness says not ready (underpopulated), split_dataset raises."""
     result = check_split_readiness(
         dataset_underpopulated,
@@ -421,7 +422,7 @@ def test_check_split_readiness_underpopulated_implies_split_raises(dataset_under
         )
 
 
-def test_stratified_splitter_multilabel_allow_oos_all_oos_raises_value_error():
+def test_stratified_splitter_multilabel_allow_oos_all_oos_raises_value_error() -> None:
     """Multilabel OOS mapping needs an in-domain row to infer label dimensionality."""
     from datasets import Dataset as HFDataset
 

--- a/tests/data/test_data_handler.py
+++ b/tests/data/test_data_handler.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from typing import Any
 
 import pytest
 
@@ -10,7 +11,7 @@ from autointent.schemas import Sample
 
 
 @pytest.fixture
-def sample_multiclass_data():
+def sample_multiclass_data() -> dict[str, Any]:
     return {
         "train": [
             {"utterance": "hello", "label": 0},
@@ -46,7 +47,7 @@ def sample_multiclass_data():
 
 
 @pytest.fixture
-def sample_multilabel_data():
+def sample_multilabel_data() -> dict[str, Any]:
     return {
         "train": [
             {"utterance": "hello and goodbye", "label": [0, 1]},
@@ -69,11 +70,11 @@ def sample_multilabel_data():
     }
 
 
-def mock_split():
+def mock_split() -> list[dict[str, Any]]:
     return [{"utterance": "Hello!", "label": 0}]
 
 
-def test_data_handler_initialization(sample_multiclass_data):
+def test_data_handler_initialization(sample_multiclass_data: dict[str, Any]) -> None:
     handler = DataHandler(
         dataset=Dataset.from_dict(sample_multiclass_data), config=DataConfig(separation_ratio=0.5), random_seed=42
     )
@@ -86,7 +87,7 @@ def test_data_handler_initialization(sample_multiclass_data):
     assert handler.test_labels() == [0, 1]
 
 
-def test_data_handler_multilabel_mode(sample_multilabel_data):
+def test_data_handler_multilabel_mode(sample_multilabel_data: dict[str, Any]) -> None:
     handler = DataHandler(
         dataset=Dataset.from_dict(sample_multilabel_data), config=DataConfig(separation_ratio=0.5), random_seed=42
     )
@@ -105,13 +106,13 @@ def test_data_handler_multilabel_mode(sample_multilabel_data):
 
 
 @pytest.mark.parametrize("label", [0, [0, 1, 0], None])
-def test_sample_initialization(label):
+def test_sample_initialization(label: int | list[int] | None) -> None:
     sample = Sample(utterance="Hello!", label=label)
     assert sample.label == label
 
 
 @pytest.mark.parametrize("label", [-1, [-1], []])
-def test_sample_validation(label):
+def test_sample_validation(label: int | list[int]) -> None:
     with pytest.raises(ValueError):  # noqa: PT011
         Sample(utterance="Hello!", label=label)
 
@@ -139,7 +140,7 @@ def test_sample_validation(label):
         },
     ],
 )
-def test_dataset_initialization(mapping):
+def test_dataset_initialization(mapping: dict[str, list[dict[str, Any]]]) -> None:
     dataset = Dataset.from_dict(mapping)
     for split in mapping:
         assert split in dataset
@@ -161,7 +162,7 @@ def test_dataset_initialization(mapping):
         {"train": mock_split(), "validation": mock_split(), "validation_0": mock_split(), "validation_1": mock_split()},
     ],
 )
-def test_dataset_validation(mapping):
+def test_dataset_validation(mapping: dict[str, list[dict[str, Any]]]) -> None:
     with pytest.raises(ValueError):  # noqa: PT011
         Dataset.from_dict(mapping)
 
@@ -178,16 +179,16 @@ def test_dataset_validation(mapping):
         {"train": [{"utterance": "Hello!"}]},
     ],
 )
-def test_intents_validation(mapping):
+def test_intents_validation(mapping: dict[str, list[dict[str, Any]]]) -> None:
     with pytest.raises(ValueError):  # noqa: PT011
         Dataset.from_dict(mapping)
 
 
-def count_oos(split):
+def count_oos(split: Any) -> int:
     return len(split.filter(lambda sample: sample["label"] is None))
 
 
-def test_cv_folding(dataset):
+def test_cv_folding(dataset: Dataset) -> None:
     DataHandler(dataset, config=DataConfig(scheme="cv", n_folds=3))
 
     desired_specs = {
@@ -202,11 +203,11 @@ def test_cv_folding(dataset):
         assert count_oos(dataset[split_name]) == desired_specs[split_name]["oos"]
 
 
-def count_oos_labels(split):
+def count_oos_labels(split: list[Any]) -> int:
     return sum(sample is None for sample in split)
 
 
-def test_cv_iterator(dataset):
+def test_cv_iterator(dataset: Dataset) -> None:
     dh = DataHandler(dataset, config=DataConfig(scheme="cv", n_folds=3))
 
     desired_specs = [
@@ -232,7 +233,7 @@ def test_cv_iterator(dataset):
         assert count_oos_labels(y_val) == specs["val"]["oos"]
 
 
-def test_few_shot_split(dataset):
+def test_few_shot_split(dataset: Dataset) -> None:
     dh = DataHandler(dataset, config=DataConfig(scheme="ho", is_few_shot_train=True, examples_per_intent=2))
 
     desired_specs = {
@@ -249,7 +250,7 @@ def test_few_shot_split(dataset):
         )
 
 
-def _make_multiclass_mapping_with_oos(*, with_validation: bool) -> dict:
+def _make_multiclass_mapping_with_oos(*, with_validation: bool) -> dict[str, Any]:
     # Ensure enough samples per class so stratified splitting doesn't fail.
     in_domain = [{"utterance": f"c0_{i}", "label": 0} for i in range(50)] + [
         {"utterance": f"c1_{i}", "label": 1} for i in range(50)
@@ -257,7 +258,7 @@ def _make_multiclass_mapping_with_oos(*, with_validation: bool) -> dict:
 
     oos = [{"utterance": f"oos_{i}"} for i in range(20)]
 
-    mapping: dict = {
+    mapping: dict[str, Any] = {
         "train": [*in_domain, *oos],
         "intents": [{"id": 0}, {"id": 1}],
     }
@@ -279,7 +280,7 @@ def _split_has_oos_labels(dh: DataHandler, split_name: str) -> bool:
     return any(lab is None for lab in dh.dataset[split_name][dh.dataset.label_feature])
 
 
-def test_ho_oos_without_separation_ratio_duplicates_and_filters_scoring_splits():
+def test_ho_oos_without_separation_ratio_duplicates_and_filters_scoring_splits() -> None:
     """If OOS exists and separation_ratio is None, scoring splits must be OOS-free."""
     dataset = Dataset.from_dict(_make_multiclass_mapping_with_oos(with_validation=False))
     dh = DataHandler(dataset, config=DataConfig(scheme="ho", separation_ratio=None), random_seed=42)
@@ -297,7 +298,7 @@ def test_ho_oos_without_separation_ratio_duplicates_and_filters_scoring_splits()
     assert _split_has_oos_labels(dh, "validation_1") is True
 
 
-def test_ho_oos_with_user_validation_duplicates_validation_when_needed():
+def test_ho_oos_with_user_validation_duplicates_validation_when_needed() -> None:
     """If user provides validation with OOS, it should be duplicated and filtered for scoring."""
     dataset = Dataset.from_dict(_make_multiclass_mapping_with_oos(with_validation=True))
     dh = DataHandler(dataset, config=DataConfig(scheme="ho", separation_ratio=None), random_seed=42)

--- a/tests/data/test_oos_handling.py
+++ b/tests/data/test_oos_handling.py
@@ -12,11 +12,11 @@ if TYPE_CHECKING:
     from datasets import Dataset as HFDataset
 
 
-def count_oos(split: HFDataset):
+def count_oos(split: HFDataset) -> int:
     return len(split.filter(lambda sample: sample["label"] is None))
 
 
-def create_clinc150_subset():
+def create_clinc150_subset() -> Dataset:
     snapshot_path = ires.files("tests.assets.data").joinpath("clinc150_oos_input.json")
     clinc = Dataset.from_json(str(snapshot_path))
 
@@ -49,7 +49,7 @@ def create_clinc150_subset():
     )
 
 
-def test():
+def test() -> None:
     dataset = create_clinc150_subset()
 
     desired_specs = {

--- a/tests/data/test_stratificaiton.py
+++ b/tests/data/test_stratificaiton.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from autointent import Dataset
@@ -5,9 +7,9 @@ from autointent.context.data_handler._stratification import split_dataset
 from autointent.custom_types import Split
 
 
-def test_train_test_split(dataset_unsplitted):
+def test_train_test_split(dataset_unsplitted: Dataset) -> None:
     dataset = dataset_unsplitted
-    kwargs = {
+    kwargs: dict[str, Any] = {
         "dataset": dataset,
         "split": Split.TRAIN,
         "test_size": 0.5,
@@ -26,7 +28,7 @@ def test_train_test_split(dataset_unsplitted):
     assert dataset.get_n_classes(Split.TRAIN) == dataset.get_n_classes(Split.TEST)
 
 
-def test_multilabel_train_test_split(dataset_unsplitted):
+def test_multilabel_train_test_split(dataset_unsplitted: Dataset) -> None:
     dataset = dataset_unsplitted
     dataset = dataset.to_multilabel()
     dataset[Split.TRAIN], dataset[Split.TEST] = split_dataset(
@@ -44,7 +46,7 @@ def test_multilabel_train_test_split(dataset_unsplitted):
     assert dataset.get_n_classes(Split.TRAIN) == dataset.get_n_classes(Split.TEST)
 
 
-def test_multilabel_train_test_split_multi_hot_preserves_label_coverage():
+def test_multilabel_train_test_split_multi_hot_preserves_label_coverage() -> None:
     dataset = Dataset.from_dict(
         {
             "train": [
@@ -72,7 +74,7 @@ def test_multilabel_train_test_split_multi_hot_preserves_label_coverage():
     assert dataset.get_n_classes(Split.TRAIN) == dataset.get_n_classes(Split.TEST) == dataset.n_classes
 
 
-def test_multilabel_train_test_split_few_shot(dataset_unsplitted):
+def test_multilabel_train_test_split_few_shot(dataset_unsplitted: Dataset) -> None:
     dataset = dataset_unsplitted
     dataset = dataset.to_multilabel()
     dataset[Split.TRAIN], dataset[Split.TEST] = split_dataset(
@@ -93,7 +95,7 @@ def test_multilabel_train_test_split_few_shot(dataset_unsplitted):
 
 
 @pytest.mark.parametrize("allow_oos_in_train", [True, False])
-def test_multiclass_train_test_split_few_shot(dataset_unsplitted, allow_oos_in_train):
+def test_multiclass_train_test_split_few_shot(dataset_unsplitted: Dataset, allow_oos_in_train: bool) -> None:
     train_num_rows = 10 if allow_oos_in_train else 8
     test_num_rows = 26 if allow_oos_in_train else 28
     examples_per_intent = 2


### PR DESCRIPTION
Phase B subagent B5 diff for strict-mypy-on-tests. See docs/superpowers/specs/2026-06-07-mypy-on-tests-design.md. CI on this PR is the verification surface — pytest + typing run on GitHub Actions, not locally.