### PR TITLE
test(types): annotate tests/modules/{embedding,test_dumper,test_regex} (45→0 mypy errors)

### DIFF
--- a/tests/modules/embedding/test_logreg.py
+++ b/tests/modules/embedding/test_logreg.py
@@ -1,16 +1,18 @@
 import numpy as np
 
+from autointent.configs import HashingVectorizerEmbeddingConfig
 from autointent.modules.embedding import LogregAimedEmbedding
 from tests.conftest import get_test_embedder_config, setup_environment
 
 
-def test_get_assets_returns_correct_artifact_for_logreg():
+def test_get_assets_returns_correct_artifact_for_logreg() -> None:
     module = LogregAimedEmbedding(embedder_config=get_test_embedder_config())
     artifact = module.get_assets()
+    assert isinstance(artifact.config, HashingVectorizerEmbeddingConfig)
     assert artifact.config.n_features == 512
 
 
-def test_fit_trains_model():
+def test_fit_trains_model() -> None:
     module = LogregAimedEmbedding(embedder_config=get_test_embedder_config())
 
     utterances = ["hello", "goodbye", "hi", "bye", "bye", "hello", "welcome", "hi123", "hiii", "bye-bye", "bye!"]
@@ -19,10 +21,11 @@ def test_fit_trains_model():
 
     assert module._classifier.coef_ is not None
     assert len(module._classifier.coef_) > 0
+    assert module._label_encoder is not None
     assert module._label_encoder.classes_.tolist() == [0, 1]
 
 
-def test_predict_evaluates_model():
+def test_predict_evaluates_model() -> None:
     module = LogregAimedEmbedding(embedder_config=get_test_embedder_config())
 
     utterances = ["hello", "goodbye", "hi", "bye", "bye", "hello", "welcome", "hi123", "hiii", "bye-bye", "bye!"]
@@ -36,7 +39,7 @@ def test_predict_evaluates_model():
     assert probas[1][1] > probas[1][0]
 
 
-def test_dump_load():
+def test_dump_load() -> None:
     module = LogregAimedEmbedding(embedder_config=get_test_embedder_config())
     utterances = ["hello", "goodbye", "hi", "bye", "bye", "hello", "welcome", "hi123", "hiii", "bye-bye", "bye!"]
     labels = [0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1]
@@ -45,8 +48,8 @@ def test_dump_load():
 
     dump_path = setup_environment()
 
-    module.dump(dump_path)
+    module.dump(str(dump_path))
     del module
-    module = LogregAimedEmbedding.load(dump_path)
+    module = LogregAimedEmbedding.load(str(dump_path))
     predictions_loaded = module.predict(["hello", "bye"])
     assert np.allclose(predictions, predictions_loaded)

--- a/tests/modules/embedding/test_retrieval.py
+++ b/tests/modules/embedding/test_retrieval.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from autointent.configs import HashingVectorizerEmbeddingConfig
 from autointent.modules.embedding import RetrievalAimedEmbedding
 from tests.conftest import get_test_embedder_config
 
@@ -9,13 +10,14 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def test_get_assets_returns_correct_artifact():
+def test_get_assets_returns_correct_artifact() -> None:
     module = RetrievalAimedEmbedding(k=5, embedder_config=get_test_embedder_config())
     artifact = module.get_assets()
+    assert isinstance(artifact.config, HashingVectorizerEmbeddingConfig)
     assert artifact.config.n_features == 512
 
 
-def test_dump_and_load_preserves_model_state(tmp_path: Path):
+def test_dump_and_load_preserves_model_state(tmp_path: Path) -> None:
     module = RetrievalAimedEmbedding(k=5, embedder_config=get_test_embedder_config())
 
     utterances = ["hello", "goodbye", "hi", "bye", "bye", "hello", "welcome", "hi123", "hiii", "bye-bye", "bye!"]
@@ -23,9 +25,9 @@ def test_dump_and_load_preserves_model_state(tmp_path: Path):
     module.fit(utterances, labels)
     predictions = module.predict(utterances)
 
-    module.dump(tmp_path)
+    module.dump(str(tmp_path))
     del module
 
-    loaded_module = RetrievalAimedEmbedding.load(tmp_path)
+    loaded_module = RetrievalAimedEmbedding.load(str(tmp_path))
     predictions_loaded = loaded_module.predict(utterances)
     assert predictions == predictions_loaded

--- a/tests/modules/test_dumper.py
+++ b/tests/modules/test_dumper.py
@@ -14,14 +14,14 @@ from tests.conftest import get_test_embedder_config, tiny_cross_encoder_config
 
 
 class TestSimpleAttributes:
-    def init_attributes(self):
+    def init_attributes(self) -> None:
         self.integer = 1
         self.float = 1.0
         self.string = "test"
         self.boolean = True
         self.array = np.array([1, 2, 3])
 
-    def check_attributes(self):
+    def check_attributes(self) -> None:
         assert self.integer == 1
         assert self.float == 1.0
         assert self.string == "test"
@@ -30,18 +30,19 @@ class TestSimpleAttributes:
 
 
 class TestTags:
-    def init_attributes(self):
+    def init_attributes(self) -> None:
         self.tags = TagsList(tags=[Tag(name="hello", intent_ids=[0]), Tag(name="world", intent_ids=[1])])
 
-    def check_attributes(self):
+    def check_attributes(self) -> None:
         assert self.tags == TagsList(tags=[Tag(name="hello", intent_ids=[0]), Tag(name="world", intent_ids=[1])])
 
 
 class TestTransformers:
-    def init_attributes(self):
+    def init_attributes(self) -> None:
         from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-        self.tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+        # reason: transformers AutoTokenizer.from_pretrained is untyped in stubs
+        self.tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")  # type: ignore[no-untyped-call]
         self._tokenizer_predictions = np.array(self.tokenizer(["hello", "world"]).input_ids)
         self.transformer = AutoModelForSequenceClassification.from_pretrained("bert-base-uncased")
 
@@ -50,7 +51,7 @@ class TestTransformers:
                 self.transformer(input_ids=torch.tensor(self._tokenizer_predictions)).logits.cpu().numpy()
             )
 
-    def check_attributes(self):
+    def check_attributes(self) -> None:
         tokenizer_predictions = self.tokenizer(["hello", "world"]).input_ids
         np.testing.assert_almost_equal(self._tokenizer_predictions, tokenizer_predictions, decimal=4)
         with torch.no_grad():
@@ -62,25 +63,25 @@ class TestTransformers:
 
 
 class TestVectorIndex:
-    def init_attributes(self):
+    def init_attributes(self) -> None:
         self.vector_index = VectorIndex(
             embedder_config=get_test_embedder_config(),
             config=FaissConfig(),
         )
         self.vector_index.add(texts=["hello", "world"], labels=[0, 1])
 
-    def check_attributes(self):
+    def check_attributes(self) -> None:
         assert self.vector_index.config == FaissConfig()
 
 
 class TestEmbedder:
-    def init_attributes(self):
+    def init_attributes(self) -> None:
         self.embedder = Embedder(
             embedder_config=get_test_embedder_config(),
         )
         self._embedder_predictions = self.embedder.embed(["hello", "world"])
 
-    def check_attributes(self):
+    def check_attributes(self) -> None:
         np.testing.assert_almost_equal(
             self._embedder_predictions,
             self.embedder.embed(["hello", "world"]),
@@ -89,12 +90,12 @@ class TestEmbedder:
 
 
 class TestSklearnEstimator:
-    def init_attributes(self):
+    def init_attributes(self) -> None:
         self.estimator = LogisticRegression()
         self.estimator.fit([[1, 2, 3], [4, 5, 6]], [0, 1])
         self._estimator_predictions = self.estimator.predict([[1, 2, 3], [4, 5, 6]])
 
-    def check_attributes(self):
+    def check_attributes(self) -> None:
         np.testing.assert_almost_equal(
             self._estimator_predictions,
             self.estimator.predict([[1, 2, 3], [4, 5, 6]]),
@@ -103,7 +104,7 @@ class TestSklearnEstimator:
 
 
 class TestRanker:
-    def init_attributes(self):
+    def init_attributes(self) -> None:
         self.ranker = Ranker(
             cross_encoder_config=tiny_cross_encoder_config().model_copy(update={"train_head": True}),
         )
@@ -115,7 +116,7 @@ class TestRanker:
             [("hello", "world"), ("bye", "earth")],
         )
 
-    def check_attributes(self):
+    def check_attributes(self) -> None:
         np.testing.assert_almost_equal(
             self._ranker_predictions,
             self.ranker.predict([("hello", "world"), ("bye", "earth")]),
@@ -124,7 +125,7 @@ class TestRanker:
 
 
 class TestCrossEncoderConfig:
-    def init_attributes(self):
+    def init_attributes(self) -> None:
         self.pydantic_model = CrossEncoderConfig(
             model_name="cross-encoder/ms-marco-MiniLM-L6-v2",
             train_head=True,
@@ -134,7 +135,7 @@ class TestCrossEncoderConfig:
             tokenizer_config=TokenizerConfig(max_length=512, padding="longest", truncation=False),
         )
 
-    def check_attributes(self):
+    def check_attributes(self) -> None:
         assert self.pydantic_model.model_name == "cross-encoder/ms-marco-MiniLM-L6-v2"
         assert self.pydantic_model.train_head
         assert self.pydantic_model.device == "cpu"
@@ -190,7 +191,7 @@ def _transformers_is_installed() -> bool:
         TestCrossEncoderConfig,
     ],
 )
-def test_dumper(test_class):
+def test_dumper(test_class: type) -> None:
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         test_obj = test_class()
         test_obj.init_attributes()

--- a/tests/modules/test_regex.py
+++ b/tests/modules/test_regex.py
@@ -2,7 +2,8 @@ import tempfile
 
 import pytest
 
-from autointent.modules import SimpleRegex
+from autointent.custom_types import LabelType
+from autointent.modules.regex import SimpleRegex
 from autointent.schemas import Intent
 
 
@@ -10,7 +11,7 @@ from autointent.schemas import Intent
     ("partial_match", "expected_predictions"),
     [(".*", [[0, 1], [0, 1], [0, 1], [0, 1], [0, 1]]), ("frozen", [[0], [0], [0], [0], [0, 1]])],
 )
-def test_base_regex(partial_match, expected_predictions):
+def test_base_regex(partial_match: str, expected_predictions: list[LabelType]) -> None:
     train_data = [
         Intent(id=0, name="accept_reservations", regex_full_match=[".*"], regex_partial_match=[".*"]),
         Intent(id=1, name="account_blocked", regex_partial_match=[partial_match]),
@@ -30,6 +31,7 @@ def test_base_regex(partial_match, expected_predictions):
     assert predictions == expected_predictions
 
     predictions, metadata = matcher.predict_with_metadata(test_data)
+    assert metadata is not None
     assert len(predictions) == len(test_data) == len(metadata)
 
     assert "partial_matches" in metadata[0]


### PR DESCRIPTION
Phase B subagent B3 diff for strict-mypy-on-tests. See docs/superpowers/specs/2026-06-07-mypy-on-tests-design.md. CI on this PR is the verification surface — pytest + typing run on GitHub Actions, not locally.