### PR TITLE
test(types): annotate tests/{callback,ci,metrics} (34→0 mypy errors)

### DIFF
--- a/tests/callback/test_callback.py
+++ b/tests/callback/test_callback.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from copy import deepcopy
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
@@ -8,12 +10,15 @@ from autointent._callbacks import CallbackHandler, OptimizerCallback
 from autointent.configs import DataConfig, FaissConfig, HPOConfig, LoggingConfig
 from tests.conftest import setup_environment
 
+if TYPE_CHECKING:
+    from autointent import Dataset
+
 
 class DummyCallback(OptimizerCallback):
     name = "dummy"
 
     def __init__(self) -> None:
-        self.history = []
+        self.history: list[tuple[str, Any]] = []
 
     def start_run(self, **kwargs: dict[str, Any]) -> None:
         self.history.append(("start_run", kwargs))
@@ -51,10 +56,10 @@ class DummyCallback(OptimizerCallback):
         return metrics
 
 
-def test_pipeline_callbacks(dataset):
+def test_pipeline_callbacks(dataset: Dataset) -> None:
     project_dir = setup_environment()
 
-    search_space = [
+    search_space: list[dict[str, Any]] = [
         {
             "node_type": "embedding",
             "target_metric": "retrieval_hit_rate",
@@ -104,7 +109,7 @@ def test_pipeline_callbacks(dataset):
 
     pipeline_optimizer._fit(context)
 
-    dummy_callback = context.callback_handler.callbacks[0]
+    dummy_callback = cast("DummyCallback", context.callback_handler.callbacks[0])
 
     assert len(dummy_callback.history) == 30
     assert dummy_callback.history[0][0] == "start_run"

--- a/tests/callback/test_callback.py
+++ b/tests/callback/test_callback.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -109,7 +109,8 @@ def test_pipeline_callbacks(dataset: Dataset) -> None:
 
     pipeline_optimizer._fit(context)
 
-    dummy_callback = cast("DummyCallback", context.callback_handler.callbacks[0])
+    dummy_callback = context.callback_handler.callbacks[0]
+    assert isinstance(dummy_callback, DummyCallback)
 
     assert len(dummy_callback.history) == 30
     assert dummy_callback.history[0][0] == "start_run"

--- a/tests/ci/test_warm_hf_cache.py
+++ b/tests/ci/test_warm_hf_cache.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 import warm_hf_cache as wc
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 class TestResolveEntry:
-    def test_known_repo_resolves_to_pinned_sha(self):
+    def test_known_repo_resolves_to_pinned_sha(self) -> None:
         entry = wc._resolve_entry("prajjwal1/bert-tiny", "model")
         assert entry.repo_id == "prajjwal1/bert-tiny"
         assert entry.repo_type == "model"
@@ -14,19 +19,19 @@ class TestResolveEntry:
         from autointent.configs._pinned_revisions import DEFAULT_REVISIONS
         assert entry.revision == DEFAULT_REVISIONS["prajjwal1/bert-tiny"]
 
-    def test_unknown_repo_raises(self):
+    def test_unknown_repo_raises(self) -> None:
         with pytest.raises(wc.ConfigError, match="not in DEFAULT_REVISIONS"):
             wc._resolve_entry("not-a-real/repo", "model")
 
 
 class TestLoadConfig:
-    def test_empty_file(self, tmp_path):
+    def test_empty_file(self, tmp_path: Path) -> None:
         cfg = tmp_path / "empty.yaml"
         cfg.write_text("models: []\ndatasets: []\n")
         entries = wc._load_config(cfg)
         assert entries == []
 
-    def test_models_resolved_via_default_revisions(self, tmp_path):
+    def test_models_resolved_via_default_revisions(self, tmp_path: Path) -> None:
         from autointent.configs._pinned_revisions import DEFAULT_REVISIONS
 
         cfg = tmp_path / "cfg.yaml"
@@ -44,19 +49,19 @@ class TestLoadConfig:
             ),
         ]
 
-    def test_unknown_top_level_key_raises(self, tmp_path):
+    def test_unknown_top_level_key_raises(self, tmp_path: Path) -> None:
         cfg = tmp_path / "cfg.yaml"
         cfg.write_text("models: []\nfoo: []\n")
         with pytest.raises(wc.ConfigError, match="Unknown top-level"):
             wc._load_config(cfg)
 
-    def test_unpinned_model_raises(self, tmp_path):
+    def test_unpinned_model_raises(self, tmp_path: Path) -> None:
         cfg = tmp_path / "cfg.yaml"
         cfg.write_text("models:\n  - not-a-real/repo\n")
         with pytest.raises(wc.ConfigError, match="not in DEFAULT_REVISIONS"):
             wc._load_config(cfg)
 
-    def test_dataset_entry_raises(self, tmp_path):
+    def test_dataset_entry_raises(self, tmp_path: Path) -> None:
         # DEFAULT_REVISIONS covers models only today. If we ever need to
         # warm a dataset, _resolve_entry must be extended; the parser
         # raises until then so a dataset in the YAML can't silently
@@ -78,7 +83,7 @@ class TestPrewarmConfigsAreSubsetOfDefaultRevisions:
     misconfigured YAML never reaches the warm-cache job."""
 
     @pytest.mark.parametrize("yaml_path", [".ci/hf-prewarm.yaml"])
-    def test_every_model_is_pinned_in_default_revisions(self, yaml_path):
+    def test_every_model_is_pinned_in_default_revisions(self, yaml_path: str) -> None:
         from pathlib import Path
 
         import yaml as pyyaml
@@ -95,7 +100,7 @@ class TestPrewarmConfigsAreSubsetOfDefaultRevisions:
         )
 
     @pytest.mark.parametrize("yaml_path", [".ci/hf-prewarm.yaml"])
-    def test_no_sha_suffix_in_repo_ids(self, yaml_path):
+    def test_no_sha_suffix_in_repo_ids(self, yaml_path: str) -> None:
         """The new YAML format is bare repo IDs. A '@' in an entry means
         someone added an entry in the old 'repo@sha' format — likely
         because they copy-pasted from git history. Catch it explicitly so

--- a/tests/ci/test_warm_hf_cache.py
+++ b/tests/ci/test_warm_hf_cache.py
@@ -17,6 +17,7 @@ class TestResolveEntry:
         # The SHA must match DEFAULT_REVISIONS — we look it up here rather
         # than hardcoding to keep this test honest if the pin moves.
         from autointent.configs._pinned_revisions import DEFAULT_REVISIONS
+
         assert entry.revision == DEFAULT_REVISIONS["prajjwal1/bert-tiny"]
 
     def test_unknown_repo_raises(self) -> None:
@@ -35,11 +36,7 @@ class TestLoadConfig:
         from autointent.configs._pinned_revisions import DEFAULT_REVISIONS
 
         cfg = tmp_path / "cfg.yaml"
-        cfg.write_text(
-            "models:\n"
-            "  - prajjwal1/bert-tiny\n"
-            "datasets: []\n"
-        )
+        cfg.write_text("models:\n  - prajjwal1/bert-tiny\ndatasets: []\n")
         entries = wc._load_config(cfg)
         assert entries == [
             wc.Entry(
@@ -67,11 +64,7 @@ class TestLoadConfig:
         # raises until then so a dataset in the YAML can't silently
         # regress to an unpinned download.
         cfg = tmp_path / "cfg.yaml"
-        cfg.write_text(
-            "models: []\n"
-            "datasets:\n"
-            "  - DeepPavlov/clinc150\n"
-        )
+        cfg.write_text("models: []\ndatasets:\n  - DeepPavlov/clinc150\n")
         with pytest.raises(wc.ConfigError, match="not in DEFAULT_REVISIONS"):
             wc._load_config(cfg)
 

--- a/tests/metrics/test_oos_handling.py
+++ b/tests/metrics/test_oos_handling.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from autointent.metrics.decision import handle_oos
+
+if TYPE_CHECKING:
+    from autointent.custom_types import ListOfGenericLabels, ListOfLabels
 
 
 @pytest.mark.parametrize(
@@ -15,7 +22,12 @@ from autointent.metrics.decision import handle_oos
         ),
     ],
 )
-def test_oos_handling(y_true, y_pred, expected_true, expected_pred):
+def test_oos_handling(
+    y_true: ListOfGenericLabels,
+    y_pred: ListOfGenericLabels,
+    expected_true: ListOfLabels,
+    expected_pred: ListOfLabels,
+) -> None:
     handled_true, handled_pred = handle_oos(y_true, y_pred)
     assert handled_true == expected_true
     assert handled_pred == expected_pred

--- a/tests/metrics/test_retrieval_metrics.py
+++ b/tests/metrics/test_retrieval_metrics.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -8,6 +12,10 @@ from autointent.metrics.retrieval import (
     retrieval_ndcg,
     retrieval_precision,
 )
+
+if TYPE_CHECKING:
+    from autointent.custom_types import ListOfLabels, ListOfLabelsWithOOS
+    from autointent.metrics.custom_types import CANDIDATE_TYPE
 
 
 @pytest.mark.parametrize(
@@ -22,7 +30,12 @@ from autointent.metrics.retrieval import (
         ([3, 1], [[2, 1, 1], [2, 4, 4]], None, 0.0),
     ],
 )
-def test_map(query_labels, candidates_labels, k, ground_truth):
+def test_map(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
     output = retrieval_map(query_labels, candidates_labels, k)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -38,7 +51,12 @@ def test_map(query_labels, candidates_labels, k, ground_truth):
         ([1, 3], [[2, 1, 1], [3, 1, 1]], 2, 1.0),
     ],
 )
-def test_hit_rate(query_labels, candidates_labels, k, ground_truth):
+def test_hit_rate(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
     output = retrieval_hit_rate(query_labels, candidates_labels, k)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -54,7 +72,12 @@ def test_hit_rate(query_labels, candidates_labels, k, ground_truth):
         ([1, 3], [[2, 1, 1], [3, 1, 1]], 2, 0.5),
     ],
 )
-def test_precision(query_labels, candidates_labels, k, ground_truth):
+def test_precision(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
     output = retrieval_precision(query_labels, candidates_labels, k)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -70,7 +93,12 @@ def test_precision(query_labels, candidates_labels, k, ground_truth):
         ([1, 3], [[2, 1, 1], [3, 1, 1]], 2, 0.6934264036172708),
     ],
 )
-def test_ndcg(query_labels, candidates_labels, k, ground_truth):
+def test_ndcg(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
     output = retrieval_ndcg(query_labels, candidates_labels, k)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -86,7 +114,12 @@ def test_ndcg(query_labels, candidates_labels, k, ground_truth):
         ([1, 3], [[2, 1, 1], [3, 1, 1]], 2, 0.75),
     ],
 )
-def test_mrr(query_labels, candidates_labels, k, ground_truth):
+def test_mrr(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
     output = retrieval_mrr(query_labels, candidates_labels, k)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -98,5 +131,11 @@ def test_mrr(query_labels, candidates_labels, k, ground_truth):
         ([0, 1, 2, None], [[0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2]], 1),
     ],
 )
-def test_oos_ignoring(query_labels, candidates_labels, ground_truth):
-    assert ground_truth == retrieval_hit_rate(query_labels, candidates_labels)
+def test_oos_ignoring(
+    query_labels: ListOfLabelsWithOOS,
+    candidates_labels: CANDIDATE_TYPE,
+    ground_truth: float,
+) -> None:
+    # retrieval_hit_rate is decorated with @ignore_oos which accepts OOS-bearing labels at runtime
+    # even though its public signature is LABELS_VALUE_TYPE (without OOS).
+    assert ground_truth == retrieval_hit_rate(query_labels, candidates_labels)  # type: ignore[arg-type]  # reason: ignore_oos decorator runtime-accepts OOS labels; src signature doesn't reflect that

--- a/tests/metrics/test_retrieval_metrics_intersecting.py
+++ b/tests/metrics/test_retrieval_metrics_intersecting.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -8,6 +12,10 @@ from autointent.metrics.retrieval import (
     retrieval_ndcg_intersecting,
     retrieval_precision_intersecting,
 )
+
+if TYPE_CHECKING:
+    from autointent.custom_types import ListOfLabels, ListOfLabelsWithOOS
+    from autointent.metrics.custom_types import CANDIDATE_TYPE
 
 
 @pytest.mark.parametrize(
@@ -23,7 +31,12 @@ from autointent.metrics.retrieval import (
         ([[1, 0, 1]], [[[0, 0, 0], [0, 1, 0], [0, 1, 0]]], 2, 0.0),
     ],
 )
-def test_map(query_labels, candidates_labels, k, ground_truth):
+def test_map(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
     output = retrieval_map_intersecting(query_labels, candidates_labels, k)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -41,7 +54,12 @@ def test_map(query_labels, candidates_labels, k, ground_truth):
         ([[1, 0, 1]], [[[0, 0, 0], [0, 1, 0], [0, 1, 0]]], 2, 0.0),
     ],
 )
-def test_hit_rate(query_labels, candidates_labels, k, ground_truth):
+def test_hit_rate(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
     output = retrieval_hit_rate_intersecting(query_labels, candidates_labels, k)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -56,7 +74,12 @@ def test_hit_rate(query_labels, candidates_labels, k, ground_truth):
         ([[1, 0, 1], [0, 1, 1]], [[[1, 0, 0], [0, 1, 0], [0, 0, 1]], [[1, 0, 0], [1, 0, 0], [0, 0, 1]]], 2, 0.25),
     ],
 )
-def test_precision(query_labels, candidates_labels, k, ground_truth):
+def test_precision(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
     output = retrieval_precision_intersecting(query_labels, candidates_labels, k)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -85,7 +108,12 @@ def test_precision(query_labels, candidates_labels, k, ground_truth):
         ),
     ],
 )
-def test_ndcg(query_labels, candidates_labels, k, ground_truth):
+def test_ndcg(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
     output = retrieval_ndcg_intersecting(query_labels, candidates_labels, k)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -118,7 +146,12 @@ def test_ndcg(query_labels, candidates_labels, k, ground_truth):
         ),
     ],
 )
-def test_mrr(query_labels, candidates_labels, k, ground_truth):
+def test_mrr(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
     output = retrieval_mrr_intersecting(query_labels, candidates_labels, k)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -134,5 +167,11 @@ def test_mrr(query_labels, candidates_labels, k, ground_truth):
         ([[0, 1], [0, 1], [0, 1], None], [[[0, 1], [0, 1]], [[0, 1], [0, 1]], [[0, 1], [0, 1]], [[1, 0], [1, 0]]], 1.0),
     ],
 )
-def test_oos_ignoring(query_labels, candidates_labels, ground_truth):
-    assert ground_truth == retrieval_hit_rate_intersecting(query_labels, candidates_labels)
+def test_oos_ignoring(
+    query_labels: ListOfLabelsWithOOS,
+    candidates_labels: CANDIDATE_TYPE,
+    ground_truth: float,
+) -> None:
+    # retrieval_hit_rate_intersecting is decorated with @ignore_oos which accepts OOS-bearing labels at
+    # runtime even though its public signature is LABELS_VALUE_TYPE (without OOS).
+    assert ground_truth == retrieval_hit_rate_intersecting(query_labels, candidates_labels)  # type: ignore[arg-type]  # reason: ignore_oos decorator runtime-accepts OOS labels; src signature doesn't reflect that

--- a/tests/metrics/test_scoring_metrics.py
+++ b/tests/metrics/test_scoring_metrics.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
 from autointent.metrics.scoring import scoring_hit_rate, scoring_log_likelihood, scoring_neg_coverage, scoring_roc_auc
+
+if TYPE_CHECKING:
+    from autointent.custom_types import ListOfLabels
+    from autointent.metrics.custom_types import SCORES_VALUE_TYPE
 
 
 @pytest.mark.parametrize(
@@ -20,7 +28,7 @@ from autointent.metrics.scoring import scoring_hit_rate, scoring_log_likelihood,
         ),
     ],
 )
-def test_neg_cross_entropy(labels, scores, ground_truth):
+def test_neg_cross_entropy(labels: ListOfLabels, scores: SCORES_VALUE_TYPE, ground_truth: float) -> None:
     output = scoring_log_likelihood(labels, scores)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -60,7 +68,7 @@ def test_neg_cross_entropy(labels, scores, ground_truth):
         ),
     ],
 )
-def test_roc_auc(labels, scores, ground_truth):
+def test_roc_auc(labels: ListOfLabels, scores: SCORES_VALUE_TYPE, ground_truth: float) -> None:
     output = scoring_roc_auc(labels, scores)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -178,7 +186,7 @@ def test_roc_auc(labels, scores, ground_truth):
         ),
     ],
 )
-def test_hit_rate(labels, scores, ground_truth):
+def test_hit_rate(labels: ListOfLabels, scores: SCORES_VALUE_TYPE, ground_truth: float) -> None:
     output = scoring_hit_rate(labels, scores)
     np.testing.assert_almost_equal(output, ground_truth)
 
@@ -244,6 +252,6 @@ def test_hit_rate(labels, scores, ground_truth):
         ),
     ],
 )
-def test_coverage(labels, scores, ground_truth):
+def test_coverage(labels: ListOfLabels, scores: SCORES_VALUE_TYPE, ground_truth: float) -> None:
     output = scoring_neg_coverage(labels, scores)
     np.testing.assert_almost_equal(output, ground_truth)


### PR DESCRIPTION
Phase B subagent B10 diff for strict-mypy-on-tests. See docs/superpowers/specs/2026-06-07-mypy-on-tests-design.md. CI on this PR is the verification surface — pytest + typing run on GitHub Actions, not locally.