### PR TITLE
test: remove setup_environment helper, use pytest tmp_path

### DIFF
--- a/tests/callback/test_callback.py
+++ b/tests/callback/test_callback.py
@@ -8,9 +8,10 @@ import numpy as np
 from autointent import Context, Pipeline
 from autointent._callbacks import CallbackHandler, OptimizerCallback
 from autointent.configs import DataConfig, FaissConfig, HPOConfig, LoggingConfig
-from tests.conftest import setup_environment
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from autointent import Dataset
 
 
@@ -56,8 +57,8 @@ class DummyCallback(OptimizerCallback):
         return metrics
 
 
-def test_pipeline_callbacks(dataset: Dataset) -> None:
-    project_dir = setup_environment()
+def test_pipeline_callbacks(dataset: Dataset, tmp_path: Path) -> None:
+    project_dir = tmp_path
 
     search_space: list[dict[str, Any]] = [
         {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,12 +58,6 @@ def _disable_transformers_mistral_regex_patch() -> None:
 _disable_transformers_mistral_regex_patch()
 
 
-def setup_environment() -> Path:
-    # tests is a regular package, so importlib.resources.files returns a
-    # concrete Path here; cast asserts that to mypy without changing behavior.
-    return cast("Path", ires.files("tests").joinpath("logs"))
-
-
 def get_dataset_path() -> Path:
     return cast("Path", ires.files("tests.assets.data").joinpath("clinc_subset.json"))
 

--- a/tests/modules/decision/test_adaptive.py
+++ b/tests/modules/decision/test_adaptive.py
@@ -7,9 +7,10 @@ import pytest
 
 from autointent.exceptions import MismatchNumClassesError, WrongClassificationError
 from autointent.modules.decision import AdaptiveDecision
-from tests.conftest import setup_environment
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from tests.modules.decision.conftest import FitData
 
 
@@ -37,12 +38,12 @@ def test_fails_on_wrong_clf_problem(multiclass_fit_data: FitData) -> None:
         predictor.fit(*multiclass_fit_data)
 
 
-def test_dump_load(multilabel_fit_data: FitData) -> None:
+def test_dump_load(multilabel_fit_data: FitData, tmp_path: Path) -> None:
     predictor = AdaptiveDecision()
     predictor.fit(*multilabel_fit_data)
     preds = predictor.predict(multilabel_fit_data[0])
 
-    path = setup_environment() / "adaptive_module"
+    path = tmp_path / "adaptive_module"
     predictor.dump(str(path))
     del predictor
 

--- a/tests/modules/decision/test_argmax.py
+++ b/tests/modules/decision/test_argmax.py
@@ -7,9 +7,10 @@ import pytest
 
 from autointent.exceptions import MismatchNumClassesError, WrongClassificationError
 from autointent.modules.decision import ArgmaxDecision
-from tests.conftest import setup_environment
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import numpy.typing as npt
 
     from tests.modules.decision.conftest import FitData
@@ -36,12 +37,12 @@ def test_fails_on_wrong_clf_problem(multilabel_fit_data: FitData) -> None:
         predictor.fit(*multilabel_fit_data)
 
 
-def test_dump_load(multiclass_fit_data: FitData) -> None:
+def test_dump_load(multiclass_fit_data: FitData, tmp_path: Path) -> None:
     predictor = ArgmaxDecision()
     predictor.fit(*multiclass_fit_data)
     predictions = predictor.predict(multiclass_fit_data[0])
 
-    path = setup_environment() / "argmax_module"
+    path = tmp_path / "argmax_module"
     predictor.dump(str(path))
     del predictor
 

--- a/tests/modules/decision/test_jinoos.py
+++ b/tests/modules/decision/test_jinoos.py
@@ -7,9 +7,10 @@ import pytest
 
 from autointent.exceptions import MismatchNumClassesError, WrongClassificationError
 from autointent.modules.decision import JinoosDecision
-from tests.conftest import setup_environment
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import numpy.typing as npt
 
     from tests.modules.decision.conftest import FitData
@@ -49,12 +50,12 @@ def test_fails_on_wrong_clf_problem(multilabel_fit_data: FitData) -> None:
         predictor.fit(*multilabel_fit_data)
 
 
-def test_dump_load(multiclass_fit_data: FitData) -> None:
+def test_dump_load(multiclass_fit_data: FitData, tmp_path: Path) -> None:
     predictor = JinoosDecision()
     predictor.fit(*multiclass_fit_data)
     predictions = predictor.predict(multiclass_fit_data[0])
 
-    path = setup_environment() / "jinoos_module"
+    path = tmp_path / "jinoos_module"
     predictor.dump(str(path))
     del predictor
 

--- a/tests/modules/embedding/test_logreg.py
+++ b/tests/modules/embedding/test_logreg.py
@@ -1,10 +1,15 @@
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from autointent.configs import HashingVectorizerEmbeddingConfig
 from autointent.modules.embedding import LogregAimedEmbedding
 from tests.conftest import get_test_embedder_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_get_assets_returns_correct_artifact_for_logreg() -> None:

--- a/tests/modules/embedding/test_logreg.py
+++ b/tests/modules/embedding/test_logreg.py
@@ -1,8 +1,10 @@
+from pathlib import Path
+
 import numpy as np
 
 from autointent.configs import HashingVectorizerEmbeddingConfig
 from autointent.modules.embedding import LogregAimedEmbedding
-from tests.conftest import get_test_embedder_config, setup_environment
+from tests.conftest import get_test_embedder_config
 
 
 def test_get_assets_returns_correct_artifact_for_logreg() -> None:
@@ -39,14 +41,14 @@ def test_predict_evaluates_model() -> None:
     assert probas[1][1] > probas[1][0]
 
 
-def test_dump_load() -> None:
+def test_dump_load(tmp_path: Path) -> None:
     module = LogregAimedEmbedding(embedder_config=get_test_embedder_config())
     utterances = ["hello", "goodbye", "hi", "bye", "bye", "hello", "welcome", "hi123", "hiii", "bye-bye", "bye!"]
     labels = [0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1]
     module.fit(utterances, labels)
     predictions = module.predict(["hello", "bye"])
 
-    dump_path = setup_environment()
+    dump_path = tmp_path
 
     module.dump(str(dump_path))
     del module

--- a/tests/pipeline/test_inference.py
+++ b/tests/pipeline/test_inference.py
@@ -7,7 +7,7 @@ import pytest
 from autointent import Pipeline
 from autointent.configs import LoggingConfig, TokenizerConfig, get_default_embedder_config
 from autointent.custom_types import NodeType
-from tests.conftest import apply_test_models, get_search_space, setup_environment
+from tests.conftest import apply_test_models, get_search_space
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def project_dir(task_type: TaskType) -> Path:
-    return setup_environment() / "test_inference" / task_type
+def project_dir(tmp_path: Path) -> Path:
+    return tmp_path
 
 
 @pytest.mark.parametrize(
@@ -124,8 +124,8 @@ def test_inference_on_the_fly(
     assert prediction == prediction_v2
 
 
-def test_load_with_overrided_params(dataset: Dataset) -> None:
-    project_dir = setup_environment() / "test_inference" / "override"
+def test_load_with_overrided_params(dataset: Dataset, tmp_path: Path) -> None:
+    project_dir = tmp_path
     search_space = get_search_space("light")
 
     pipeline_optimizer = Pipeline.from_search_space(search_space)
@@ -172,8 +172,8 @@ def test_load_with_overrided_params(dataset: Dataset) -> None:
     assert loaded_scoring_module._embedder.config.tokenizer_config.max_length == 8
 
 
-def test_no_saving(dataset: Dataset) -> None:
-    project_dir = setup_environment() / "test_inference" / "no_saving"
+def test_no_saving(dataset: Dataset, tmp_path: Path) -> None:
+    project_dir = tmp_path
     search_space = get_search_space("light")
 
     pipeline_optimizer = Pipeline.from_search_space(search_space)

--- a/tests/pipeline/test_optimization.py
+++ b/tests/pipeline/test_optimization.py
@@ -7,7 +7,7 @@ import pytest
 
 from autointent import Pipeline
 from autointent.configs import DataConfig, HPOConfig, LoggingConfig
-from tests.conftest import apply_test_models, get_search_space, setup_environment
+from tests.conftest import apply_test_models, get_search_space
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -31,8 +31,8 @@ if TYPE_CHECKING:
         (DataConfig(scheme="cv", separation_ratio=0.5), True),
     ],
 )
-def test_with_regex(dataset: Dataset, data_config: DataConfig, refit_after: bool) -> None:
-    project_dir = setup_environment()
+def test_with_regex(dataset: Dataset, data_config: DataConfig, refit_after: bool, tmp_path: Path) -> None:
+    project_dir = tmp_path
     search_space = get_search_space("regex")
 
     pipeline_optimizer = Pipeline.from_search_space(search_space)
@@ -44,8 +44,8 @@ def test_with_regex(dataset: Dataset, data_config: DataConfig, refit_after: bool
     pipeline_optimizer.fit(dataset, refit_after=refit_after)
 
 
-def test_no_node_separation(dataset_no_oos: Dataset) -> None:
-    project_dir = setup_environment()
+def test_no_node_separation(dataset_no_oos: Dataset, tmp_path: Path) -> None:
+    project_dir = tmp_path
     search_space = get_search_space("light")
 
     pipeline_optimizer = Pipeline.from_search_space(search_space)
@@ -72,8 +72,8 @@ def test_full_config(dataset_no_oos: Dataset) -> None:
     "sampler",
     ["tpe", "random"],
 )
-def test_bayes(dataset: Dataset, sampler: SamplerType) -> None:
-    project_dir = setup_environment()
+def test_bayes(dataset: Dataset, sampler: SamplerType, tmp_path: Path) -> None:
+    project_dir = tmp_path
     search_space = get_search_space("optuna")
 
     pipeline_optimizer = Pipeline.from_search_space(search_space)
@@ -95,8 +95,8 @@ def test_bayes(dataset: Dataset, sampler: SamplerType) -> None:
         "description_with_llm",
     ],
 )
-def test_cv(dataset: Dataset, task_type: TaskType, patch_llm_scorer_generator: Generator) -> None:
-    project_dir = setup_environment()
+def test_cv(dataset: Dataset, task_type: TaskType, patch_llm_scorer_generator: Generator, tmp_path: Path) -> None:
+    project_dir = tmp_path
     search_space = get_search_space(task_type)
 
     pipeline_optimizer = Pipeline.from_search_space(search_space)
@@ -123,8 +123,10 @@ def test_cv(dataset: Dataset, task_type: TaskType, patch_llm_scorer_generator: G
         "description_with_llm",
     ],
 )
-def test_no_context_optimization(dataset: Dataset, task_type: TaskType, patch_llm_scorer_generator: Generator) -> None:
-    project_dir = setup_environment()
+def test_no_context_optimization(
+    dataset: Dataset, task_type: TaskType, patch_llm_scorer_generator: Generator, tmp_path: Path
+) -> None:
+    project_dir = tmp_path
     search_space = get_search_space(task_type)
 
     pipeline_optimizer = Pipeline.from_search_space(search_space)
@@ -149,8 +151,10 @@ def test_no_context_optimization(dataset: Dataset, task_type: TaskType, patch_ll
         "description_with_llm",
     ],
 )
-def test_dump_modules(dataset: Dataset, task_type: TaskType, patch_llm_scorer_generator: Generator) -> None:
-    project_dir = setup_environment()
+def test_dump_modules(
+    dataset: Dataset, task_type: TaskType, patch_llm_scorer_generator: Generator, tmp_path: Path
+) -> None:
+    project_dir = tmp_path
     search_space = get_search_space(task_type)
 
     pipeline_optimizer = Pipeline.from_search_space(search_space)

--- a/tests/pipeline/test_presets.py
+++ b/tests/pipeline/test_presets.py
@@ -7,9 +7,11 @@ import pytest
 from autointent import Pipeline
 from autointent.configs import DataConfig, HPOConfig, LoggingConfig, SentenceTransformerEmbeddingConfig
 from autointent.nodes import NodeOptimizer
-from tests.conftest import apply_test_models, setup_environment
+from tests.conftest import apply_test_models
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from autointent import Dataset
     from autointent.generation import Generator
 
@@ -29,8 +31,8 @@ if TYPE_CHECKING:
         "zero-shot-encoders",
     ],
 )
-def test_presets(dataset: Dataset, preset: str, patch_llm_scorer_generator: Generator) -> None:
-    project_dir = setup_environment()
+def test_presets(dataset: Dataset, preset: str, patch_llm_scorer_generator: Generator, tmp_path: Path) -> None:
+    project_dir = tmp_path
 
     pipeline_optimizer = Pipeline.from_preset(preset)  # type: ignore[arg-type]  # reason: parametrize values are runtime strings; mypy can't narrow to the SearchSpacePreset Literal
     apply_test_models(pipeline_optimizer)


### PR DESCRIPTION
## Summary

Removes the `setup_environment()` helper from `tests/conftest.py` and migrates every consumer to pytest's built-in `tmp_path` fixture. Closes #314.

## Root cause of #314

The helper returned the shared `tests/logs/` directory. `LoggingConfig` then generated a `{adjective}_{noun}_{datetime-to-second}` run name underneath. Under `pytest -n auto` (xdist), two parametrizations of `test_dump_modules` whose scoring search spaces differ in *number of modules* (`description_no_llm`=2, `description_with_llm`=1, `multiclass`/`multilabel`=11) can collide on the same `run_name` within the same second. When they do, both write to the same `optuna_storage/scoring.db` with `study_name="scoring"`. Optuna's compatibility check then rejects the second `module_idx` distribution as dynamic-value-space:

```
dist_old = CategoricalDistribution(choices=(0,))      # 1-module variant
dist_new = CategoricalDistribution(choices=(0, 1))    # 2-module variant
ValueError: CategoricalDistribution does not support dynamic value space.
```

(The dict-typed embedder_config warnings the issue mentions are real but unrelated — they don't trigger the failure.)

## Fix

Each test now uses pytest's `tmp_path` fixture, which is function-scoped, parametrization-aware, and per-worker unique by construction. No two tests can ever share a directory regardless of timing or worker count.

Touched: `tests/conftest.py` (delete helper), `tests/pipeline/test_optimization.py`, `tests/pipeline/test_inference.py`, `tests/pipeline/test_presets.py`, `tests/callback/test_callback.py`, `tests/modules/embedding/test_logreg.py`, `tests/modules/decision/test_{adaptive,jinoos,argmax}.py`.

## Test plan

- [x] `pytest tests/pipeline/test_optimization.py::test_dump_modules -k description_no_llm` passes (the original failure).
- [x] `pytest tests/pipeline/test_optimization.py::test_dump_modules -n 2` passes (all 4 parametrizations under xdist).
- [x] `mypy` is clean on all 9 touched files.
- [x] `pytest tests/callback/`, `tests/modules/decision/`, `tests/modules/embedding/test_logreg.py` all pass.
- [ ] CI re-runs `test-optimization` (where the flake surfaced) several times to confirm green across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)