### PR TITLE
release: prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Compared to [0.3.0](https://github.com/deeppavlov/AutoIntent/releases/tag/v0.3.0
 
 - **Full OS × Python matrix** is now gated behind the `full-ci` PR label and `dev` pushes; ordinary PRs run a faster default matrix (#318).
 - **`mypy --strict`** is enforced on `tests/` to prevent type drift between fixtures and production code (#316).
+- **Soft `mypy` profile** added for `docs/` and `user_guides/` so tutorials and Sphinx helpers are type-checked without forcing them onto strict mode (#320).
 - **Live-API tests** (OpenAI, OpenSearch) are mocked in CI — no network calls or credentials required to run the suite locally (#301).
 - **HF cache prewarm** workflow plus a `.ci/warm_hf_cache.py` helper keyed off `DEFAULT_REVISIONS` removes the long-standing Hub rate-limit flakes in the matrix (#294).
 - **GitHub Actions** runners bumped to Node 24 images (#300).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project are documented in this file. Release notes are grouped by theme rather than listing every commit.
 
+## [0.3.1] — 2026-06-16
+
+Compared to [0.3.0](https://github.com/deeppavlov/AutoIntent/releases/tag/v0.3.0). A maintenance release focused on bug fixes, reproducibility of default Hugging Face downloads, and CI/test stability. No breaking changes.
+
+### Bug fixes
+
+- **LLM description scorer** now persists `generator_config` across `dump`/`load`, so a reloaded `LLMDescriptionScorer` rebuilds its `Generator` with the original settings instead of defaults (#302).
+- **Tunable decision threshold** test fixture updated for **Optuna 4.9** sampling order — confirms compatibility with `optuna>=4.9` (#293).
+- **faiss** typing tweak for `IndexFlatIP` to satisfy stricter `mypy` runs (#292).
+
+### Reproducible Hugging Face defaults
+
+- New canonical SHA pin map `autointent.configs._pinned_revisions.DEFAULT_REVISIONS`, applied automatically by `HFModelConfig` when `revision` is left unset. Default embedders, rerankers, and NLI models now resolve to fixed commit SHAs instead of `main`, making installs deterministic and avoiding Hub `429` rate limits under parallel CI load. To opt out, pass an explicit `revision` (including `"main"`) on the relevant config (#294).
+
+### Public API additions
+
+- New `RetrievalMetricFnWithOOS` and `ScoringMetricFnWithOOS` protocols (exported from `autointent.metrics`) describing the OOS-aware metric callables returned by the existing `ignore_oos` decorators (#316).
+
+### Tooling, CI, and tests
+
+- **Full OS × Python matrix** is now gated behind the `full-ci` PR label and `dev` pushes; ordinary PRs run a faster default matrix (#318).
+- **`mypy --strict`** is enforced on `tests/` to prevent type drift between fixtures and production code (#316).
+- **Live-API tests** (OpenAI, OpenSearch) are mocked in CI — no network calls or credentials required to run the suite locally (#301).
+- **HF cache prewarm** workflow plus a `.ci/warm_hf_cache.py` helper keyed off `DEFAULT_REVISIONS` removes the long-standing Hub rate-limit flakes in the matrix (#294).
+- **GitHub Actions** runners bumped to Node 24 images (#300).
+- **Pipeline interruption tests** restored after the sampler API removal in #296 (#303).
+- Test layout cleanup: the legacy `setup_environment` helper is gone — tests now use the standard pytest `tmp_path` fixture (#317).
+
+---
+
 ## [0.3.0] — 2026-05-19
 
 Compared to [0.2.0](https://github.com/deeppavlov/AutoIntent/releases/tag/v0.2.0).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 project = "AutoIntent"
 copyright = "2026, DeepPavlov"
 author = "DeepPavlov"
-release = "0.3.0"
+release = "0.3.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "autointent"
-version = "0.3.0"
+version = "0.3.1"
 description = "A tool for automatically configuring a text classification pipeline for intent prediction."
 license = { text = "Apache 2.0" }
 authors = [


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` `version` and `docs/source/conf.py` `release` to **0.3.1**.
- Add a themed `CHANGELOG.md` entry for 0.3.1 covering: LLM scorer `dump`/`load` fix (#302), Optuna 4.9 threshold test fix (#293), faiss typing tweak (#292), the new pinned HF default revisions surfaced via `HFModelConfig` (#294), new `RetrievalMetricFnWithOOS` / `ScoringMetricFnWithOOS` protocol exports (#316), and the CI/test stability work (#300, #301, #303, #316, #317, #318).

This is a maintenance release — no breaking changes.

## After merge (release day)

Per `CONTRIBUTING.md` "Release day":

1. Merge this PR into `dev`.
2. Tag the merge commit `v0.3.1` and push the tag.
3. Publish a GitHub Release for `v0.3.1` — this triggers PyPI publish and the multi-version docs build.

## Test plan

- [x] CI is green on this PR (default matrix; add `full-ci` label if you want the full OS × Python sweep).
- [x] `make docs` builds locally without errors and shows `release = "0.3.1"`.
- [ ] After merge + tag + release: PyPI shows `autointent==0.3.1`; `https://deeppavlov.github.io/AutoIntent/versions/v0.3.1/` loads; the version switcher lists 0.3.1 as stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)