### PR TITLE
ci: type-check user_guides and docs under a soft mypy profile

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -18,7 +18,10 @@ jobs:
       - name: Install dependencies
         run: |
           uv lock
-          uv sync --group typing --group test --extra catboost --extra peft --extra transformers --extra sentence-transformers --extra openai
+          uv sync --group typing --group test --group docs --extra catboost --extra peft --extra transformers --extra sentence-transformers --extra openai
 
       - name: Run mypy
         run: uv run mypy src/autointent tests
+
+      - name: Run mypy on documentation code
+        run: uv run mypy --namespace-packages --explicit-package-bases user_guides docs/source/conf.py docs/source/docs_utils

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ test-html:
 
 .PHONY: typing
 typing:
-	$(sh) mypy src/autointent
+	$(sh) mypy src/autointent tests
+	$(sh) mypy --namespace-packages --explicit-package-bases user_guides docs/source/conf.py docs/source/docs_utils
 
 .PHONY: lint
 lint:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 import sys
-from importlib.metadata import version
+from importlib.metadata import version as get_version
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -112,7 +112,7 @@ napoleon_attr_annotations = True
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["../_static"]
-version = version("autointent").replace("dev", "")  # may differ
+version = get_version("autointent").replace("dev", "")  # may differ
 
 BASE_URL = "https://deeppavlov.github.io/AutoIntent/versions"
 BASE_STATIC_URL = f"{BASE_URL}/dev/_static"

--- a/docs/source/docs_utils/notebook.py
+++ b/docs/source/docs_utils/notebook.py
@@ -16,17 +16,12 @@ class ReplacePattern(BaseModel, abc.ABC):
     An interface for replace patterns.
     """
 
-    @property
-    @abc.abstractmethod
-    def pattern(self) -> re.Pattern:
-        """
-        A regex pattern to replace in a text.
-        """
-        ...
+    # Regex pattern to replace in a text; defined by each concrete subclass.
+    pattern: ClassVar[re.Pattern[str]]
 
     @staticmethod
     @abc.abstractmethod
-    def replacement_string(matchobj: re.Match) -> str:
+    def replacement_string(matchobj: re.Match[str]) -> str:
         """
         Return a replacement string for a match object.
 
@@ -53,10 +48,10 @@ class InstallationCell(ReplacePattern):
     Uncomment `# %pip install {}`, add a "quiet" flag, add a comment explaining the cell.
     """
 
-    pattern: ClassVar[re.Pattern] = re.compile("\n# %pip install (.*)\n")
+    pattern: ClassVar[re.Pattern[str]] = re.compile("\n# %pip install (.*)\n")
 
     @staticmethod
-    def replacement_string(matchobj: re.Match) -> str:
+    def replacement_string(matchobj: re.Match[str]) -> str:
         return f"""
 # %%
 # installing dependencies
@@ -97,7 +92,7 @@ class DocumentationLink(ReplacePattern):
 
     """
 
-    pattern: ClassVar[re.Pattern] = re.compile(r"%doclink\((.+?)\)")
+    pattern: ClassVar[re.Pattern[str]] = re.compile(r"%doclink\((.+?)\)")
 
     @staticmethod
     def link_to_doc_page(
@@ -154,7 +149,7 @@ class DocumentationLink(ReplacePattern):
         raise ValueError(msg)
 
     @staticmethod
-    def replacement_string(matchobj: re.Match) -> str:
+    def replacement_string(matchobj: re.Match[str]) -> str:
         args = matchobj.group(1).split(",")
         return DocumentationLink.link_to_doc_page(*args)
 
@@ -200,10 +195,10 @@ class MarkdownDocumentationLink(DocumentationLink):
 
     """
 
-    pattern: ClassVar[re.Pattern] = re.compile(r"%mddoclink\((.+?)\)")
+    pattern: ClassVar[re.Pattern[str]] = re.compile(r"%mddoclink\((.+?)\)")
 
     @staticmethod
-    def replacement_string(matchobj: re.Match) -> str:
+    def replacement_string(matchobj: re.Match[str]) -> str:
         args = matchobj.group(1).split(",")
         link_text = args[-1].split(".")[-1]
         return f"[{link_text}]({DocumentationLink.link_to_doc_page(*args)})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,6 +297,8 @@ module = [
     "dspy.evaluate.auto_evaluation",
     "codecarbon",
     "catboost",
+    "jupytext",
+    "docs_utils.*",
 ]
 ignore_missing_imports = true
 
@@ -317,3 +319,22 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = ["tests.server.*"]
 ignore_errors = true
+
+# Documentation code (user_guides narrative scripts and docs/ tooling) is checked
+# with a relaxed "soft" profile: real type errors (arg-type, assignment, ...) still
+# surface, but the strict-only annotation/generics noise inappropriate for teaching
+# code is disabled. Invoked with --namespace-packages --explicit-package-bases (see
+# the `typing` Makefile target) because the guide scripts are not importable packages.
+[[tool.mypy.overrides]]
+module = [
+    "user_guides.*",
+    "docs.*",
+]
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_decorators = false
+disallow_any_generics = false
+warn_return_any = false
+warn_unreachable = false
+strict_equality = false

--- a/user_guides/advanced/02_embedder_configuration.py
+++ b/user_guides/advanced/02_embedder_configuration.py
@@ -32,7 +32,7 @@ The simplest way is to pass a model name as a string:
 from autointent.modules.scoring import KNNScorer, LinearScorer
 
 # Using just the model name - sentence-transformers handles device detection
-scorer = LinearScorer(embedder_config="sentence-transformers/all-MiniLM-L6-v2")
+scorer: KNNScorer | LinearScorer = LinearScorer(embedder_config="sentence-transformers/all-MiniLM-L6-v2")
 
 # %% [markdown]
 """

--- a/user_guides/advanced/03_automl.py
+++ b/user_guides/advanced/03_automl.py
@@ -78,7 +78,9 @@ The search space for the entire pipeline looks approximately like this:
 """
 
 # %%
-search_space = [
+from typing import Any
+
+search_space: list[dict[str, Any]] = [
     {
         "node_type": "embedding",
         "target_metric": "retrieval_hit_rate",

--- a/user_guides/advanced/04_reporting.py
+++ b/user_guides/advanced/04_reporting.py
@@ -6,7 +6,9 @@ This script demonstrates how to report the optimization process using the AutoIn
 """
 
 # %%
-search_space = [
+from typing import Any
+
+search_space: list[dict[str, Any]] = [
     {
         "node_type": "embedding",
         "target_metric": "retrieval_hit_rate",

--- a/user_guides/advanced/05_logging.py
+++ b/user_guides/advanced/05_logging.py
@@ -9,11 +9,12 @@ It will be demonstrated on toy search_space example:
 
 # %%
 from pathlib import Path
+from typing import Any
 
 from autointent import Dataset, Pipeline
 from autointent.configs import LoggingConfig
 
-search_space = [
+search_space: list[dict[str, Any]] = [
     {
         "node_type": "scoring",
         "target_metric": "scoring_roc_auc",

--- a/user_guides/basic_usage/02_modules.py
+++ b/user_guides/basic_usage/02_modules.py
@@ -199,7 +199,7 @@ model_path = Path("my_dumps/knnscorer_clinc150")
 model_path.mkdir(parents=True, exist_ok=True)
 
 print(f"💾 Saving model to: {model_path}")
-scorer.dump(model_path)
+scorer.dump(str(model_path))
 print("✅ Model saved successfully!")
 
 # Let's see what files were created
@@ -218,7 +218,7 @@ Loading is just as easy - you can restore the exact same model state without ret
 # %%
 # Load the model from disk
 print("📁 Loading saved model...")
-loaded_scorer = KNNScorer.load(model_path)
+loaded_scorer = KNNScorer.load(str(model_path))
 print("✅ Model loaded successfully!")
 
 # Verify it works the same as the original
@@ -248,7 +248,8 @@ print("  Input: 'hello world!'")
 print(f"  Prediction: {scores[0]}")
 
 # Display additional metadata if available
-print(f"  Similar examples found: {len(meta[0]['neighbors'])}")
+if meta is not None:
+    print(f"  Similar examples found: {len(meta[0]['neighbors'])}")
 
 # %% [markdown]
 """

--- a/user_guides/basic_usage/04_inference.py
+++ b/user_guides/basic_usage/04_inference.py
@@ -13,9 +13,11 @@ Here's the basic example:
 """
 
 # %%
+from typing import Any
+
 from autointent import Dataset, Pipeline
 
-search_space = [
+search_space: list[dict[str, Any]] = [
     {
         "node_type": "scoring",
         "target_metric": "scoring_roc_auc",


### PR DESCRIPTION
## Summary
- Enable mypy on documentation code (`user_guides/` narrative scripts + `docs/` tooling) so broken examples and public-API drift are caught.
- Uses a relaxed **soft** `[[tool.mypy.overrides]]` for `user_guides.*` / `docs.*`: disables only strict-only annotation/generics noise (`disallow_untyped_*`, `disallow_any_generics`, `warn_return_any`, `warn_unreachable`, `strict_equality`); real errors (`arg-type`, `assignment`, `index`, `call-overload`) still surface.
- Wired into `make typing` and the `Typing` workflow via a second pass: `mypy --namespace-packages --explicit-package-bases user_guides docs/source/conf.py docs/source/docs_utils` (the guide scripts aren't importable packages and have duplicate basenames like `01_data.py`; explicit docs paths skip generated `autoapi`/`build`/`user_guides` dirs). CI sync now includes `--group docs`.

## Fixes for surfaced errors
- Annotated `search_space: list[dict[str, Any]]` in 4 guides (`from_search_space`).
- `02_modules.py`: pass `str(model_path)` to `dump`/`load`; guard possibly-`None` metadata.
- `02_embedder_configuration.py`: annotate reused `scorer` as `KNNScorer | LinearScorer`.
- `conf.py`: alias the `importlib.metadata.version` import (was shadowed by the `version` config var).
- `notebook.py`: convert the abstract `pattern` property to a typed `ClassVar[re.Pattern[str]]` + `[str]` type args, fixing the `re.sub` `call-overload` (runtime-smoke-tested, behavior-preserving).

## Test plan
- [x] `mypy --namespace-packages --explicit-package-bases user_guides docs/source/conf.py docs/source/docs_utils` → `Success: no issues found in 14 source files`
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] Runtime smoke test of `docs_utils.notebook` (replace patterns + py→notebook conversion)
- [ ] Full docs build (`make test-docs`, ~20 min, gated behind `full-ci`) not run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)