### PR TITLE
ci: fix Windows test jobs broken by bash-only shell step

### DIFF
--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -84,14 +84,14 @@ jobs:
         # offline mode as a backstop.
         HF_HUB_DOWNLOAD_TIMEOUT: "60"
         # Unique per group so the combine job can merge them; only consulted
-        # by pytest-cov on the coverage branch below.
+        # by pytest-cov when `--cov` is appended below.
         COVERAGE_FILE: .coverage.${{ inputs.coverage_artifact }}
-      run: |
-        if [ -n "${{ inputs.coverage_artifact }}" ]; then
-          uv run ${{ inputs.test_command }} --cov --cov-report=
-        else
-          uv run ${{ inputs.test_command }}
-        fi
+      # Append `--cov` via a GitHub expression rather than a shell `if`: the
+      # default shell on windows-latest is PowerShell, where the previous
+      # bash `if [ -n ... ]; then ... fi` is a syntax error that failed every
+      # Windows test job. coverage_artifact is empty on normal push/PR runs,
+      # so the appended flags collapse to nothing and behavior is unchanged.
+      run: uv run ${{ inputs.test_command }} ${{ inputs.coverage_artifact != '' && '--cov --cov-report=' || '' }}
 
     # Hidden-file upload (the data file is `.coverage.*`) is required since
     # actions/upload-artifact excludes dotfiles by default.


### PR DESCRIPTION
## Why

PR #325 added a coverage toggle to `reusable-test.yaml`'s **Run tests** step as a bash conditional:

```yaml
run: |
  if [ -n "${{ inputs.coverage_artifact }}" ]; then
    uv run ${{ inputs.test_command }} --cov --cov-report=
  else
    uv run ${{ inputs.test_command }}
  fi
```

The step has no `shell:` override, so on `windows-latest` it runs under **PowerShell**, where `if [ -n ... ]; then ... fi` is a syntax error. Every Windows test job fails before a single test runs — including on normal (non-coverage) runs, since the script executes regardless of `coverage_artifact`.

It slipped through because the default PR matrix is ubuntu-only; Windows only runs on push-to-`dev` and `full-ci`-labeled PRs.

## What

Append `--cov` via a GitHub expression instead of a shell `if`, keeping the step shell-agnostic (works under both bash and PowerShell). On normal push/PR runs `coverage_artifact` is empty, so the appended flags collapse to nothing and behavior is identical to before.

```yaml
run: uv run ${{ inputs.test_command }} ${{ inputs.coverage_artifact != '' && '--cov --cov-report=' || '' }}
```

## Validation

- [ ] Label this PR `full-ci` so the Windows leg actually runs — the default ubuntu-only matrix won't exercise the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)