### PR TITLE
test: cover JSONFormatter and macro retrieval metrics (Tier A)

### DIFF
--- a/tests/_logging/test_formatter.py
+++ b/tests/_logging/test_formatter.py
@@ -1,0 +1,115 @@
+"""Unit tests for the JSON logging formatter.
+
+``JSONFormatter`` is a pure ``logging.Formatter`` subclass: it turns a
+``LogRecord`` into a JSON string. These tests build records by hand and assert
+the parsed JSON, so they need no logging configuration or external services.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+
+from autointent._logging.formatter import JSONFormatter
+
+
+def _raise_value_error() -> None:
+    error_message = "boom"
+    raise ValueError(error_message)
+
+
+def _record(msg: str = "hello world") -> logging.LogRecord:
+    return logging.LogRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=42,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_format_emits_message_and_timestamp() -> None:
+    payload = json.loads(JSONFormatter().format(_record()))
+
+    assert payload["message"] == "hello world"
+    # timestamp is rendered as a UTC ISO-8601 string
+    assert payload["timestamp"].endswith("+00:00")
+
+
+def test_format_interpolates_message_args() -> None:
+    record = logging.LogRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="value is %s",
+        args=("forty-two",),
+        exc_info=None,
+    )
+
+    payload = json.loads(JSONFormatter().format(record))
+
+    assert payload["message"] == "value is forty-two"
+
+
+def test_fmt_keys_remap_and_consume_always_fields() -> None:
+    formatter = JSONFormatter(fmt_keys={"level": "levelname", "logger": "name", "msg": "message"})
+
+    payload = json.loads(formatter.format(_record()))
+
+    # "level"/"logger" are pulled from record attributes
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "test.logger"
+    # "msg" maps to the always-field "message", which is then consumed
+    assert payload["msg"] == "hello world"
+    assert "message" not in payload
+    # unmapped always-fields still appear
+    assert "timestamp" in payload
+
+
+def test_format_includes_exception_info() -> None:
+    try:
+        _raise_value_error()
+    except ValueError:
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="failed",
+            args=(),
+            exc_info=sys.exc_info(),
+        )
+
+    payload = json.loads(JSONFormatter().format(record))
+
+    assert "ValueError: boom" in payload["exc_info"]
+
+
+def test_format_includes_stack_info() -> None:
+    record = logging.LogRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="with stack",
+        args=(),
+        exc_info=None,
+        sinfo="Stack (most recent call last):\n  fake frame",
+    )
+
+    payload = json.loads(JSONFormatter().format(record))
+
+    assert "Stack (most recent call last):" in payload["stack_info"]
+
+
+def test_format_includes_extra_record_attributes() -> None:
+    record = _record()
+    record.custom_field = "extra-value"
+
+    payload = json.loads(JSONFormatter().format(record))
+
+    assert payload["custom_field"] == "extra-value"

--- a/tests/metrics/test_retrieval_metrics_macro.py
+++ b/tests/metrics/test_retrieval_metrics_macro.py
@@ -1,0 +1,117 @@
+"""Unit tests for macro-averaged retrieval metrics.
+
+These cover the ``*_macro`` variants and the shared ``_macrofy`` helper, which
+binarizes multilabel inputs per class and averages the single-label metric over
+classes. Ground-truth constants are the deterministic outputs of the metric
+functions (the same convention as the other retrieval-metric tests).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from autointent.metrics.retrieval import (
+    retrieval_hit_rate_macro,
+    retrieval_map_macro,
+    retrieval_mrr_macro,
+    retrieval_ndcg_macro,
+    retrieval_precision_macro,
+)
+
+if TYPE_CHECKING:
+    from autointent.custom_types import ListOfLabels
+    from autointent.metrics.custom_types import CANDIDATE_TYPE
+
+# A single multilabel query and a two-query batch reused across metrics.
+Q_SINGLE = [[0, 1, 0]]
+C_SINGLE = [[[0, 0, 1], [0, 1, 0], [0, 1, 0]]]
+Q_BATCH = [[0, 1, 0], [0, 0, 1]]
+C_BATCH = [[[0, 0, 1], [0, 1, 0], [0, 1, 0]], [[0, 0, 1], [0, 1, 0], [0, 1, 0]]]
+
+
+@pytest.mark.parametrize(
+    ("query_labels", "candidates_labels", "k", "ground_truth"),
+    [
+        (Q_SINGLE, C_SINGLE, None, 0.7222222222222222),
+        (Q_BATCH, C_BATCH, None, 0.861111111111111),
+        (Q_BATCH, C_BATCH, 2, 0.8333333333333334),
+    ],
+)
+def test_map_macro(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
+    np.testing.assert_almost_equal(retrieval_map_macro(query_labels, candidates_labels, k), ground_truth)
+
+
+@pytest.mark.parametrize(
+    ("query_labels", "candidates_labels", "k", "ground_truth"),
+    [
+        (Q_SINGLE, C_SINGLE, None, 1.0),
+        (Q_BATCH, C_BATCH, None, 1.0),
+        (Q_BATCH, C_BATCH, 2, 1.0),
+    ],
+)
+def test_hit_rate_macro(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
+    np.testing.assert_almost_equal(retrieval_hit_rate_macro(query_labels, candidates_labels, k), ground_truth)
+
+
+@pytest.mark.parametrize(
+    ("query_labels", "candidates_labels", "k", "ground_truth"),
+    [
+        (Q_SINGLE, C_SINGLE, None, 0.7777777777777777),
+        (Q_BATCH, C_BATCH, None, 0.6666666666666666),
+        (Q_BATCH, C_BATCH, 2, 0.6666666666666666),
+    ],
+)
+def test_precision_macro(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
+    np.testing.assert_almost_equal(retrieval_precision_macro(query_labels, candidates_labels, k), ground_truth)
+
+
+@pytest.mark.parametrize(
+    ("query_labels", "candidates_labels", "k", "ground_truth"),
+    [
+        (Q_SINGLE, C_SINGLE, None, 0.7956176024115139),
+        (Q_BATCH, C_BATCH, None, 0.8978088012057569),
+        (Q_BATCH, C_BATCH, 2, 0.7956176024115139),
+    ],
+)
+def test_ndcg_macro(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
+    np.testing.assert_almost_equal(retrieval_ndcg_macro(query_labels, candidates_labels, k), ground_truth)
+
+
+@pytest.mark.parametrize(
+    ("query_labels", "candidates_labels", "k", "ground_truth"),
+    [
+        (Q_SINGLE, C_SINGLE, None, 0.6666666666666666),
+        (Q_BATCH, C_BATCH, None, 0.8333333333333334),
+        (Q_BATCH, C_BATCH, 2, 0.8333333333333334),
+    ],
+)
+def test_mrr_macro(
+    query_labels: ListOfLabels,
+    candidates_labels: CANDIDATE_TYPE,
+    k: int | None,
+    ground_truth: float,
+) -> None:
+    np.testing.assert_almost_equal(retrieval_mrr_macro(query_labels, candidates_labels, k), ground_truth)


### PR DESCRIPTION
## What

First of a short series of independent coverage PRs against `dev` (follow-up to #325). **Tier A — pure-logic, deterministic tests, no new runtime deps.**

Adds tests for two units that the suite never exercised:

- **`autointent._logging.formatter.JSONFormatter`** (was **0%**): record→JSON rendering, `fmt_keys` remapping (incl. consuming always-fields), `exc_info`, `stack_info`, and extra record attributes.
- **`autointent.metrics.retrieval`** macro variants + the shared `_macrofy` helper: `retrieval_{map,hit_rate,precision,ndcg,mrr}_macro` (previously the only untested retrieval metrics). Ground-truth constants are the deterministic metric outputs, matching the convention of the existing `test_retrieval_metrics*.py`.

## Notes

- All new tests live in the `unit-tests` CI job (not under `modules/scoring`, `pipeline`, or `embedder`).
- Verified locally with `ruff check` and `mypy --strict` (Python 3.10, matching CI). Test execution is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)