### PR TITLE
fix(embedder): stabilize offline embedding cache key, prevent cross-model collision (#321)

### DIFF
--- a/src/autointent/_wrappers/embedder/sentence_transformers.py
+++ b/src/autointent/_wrappers/embedder/sentence_transformers.py
@@ -62,9 +62,29 @@ def _get_latest_commit_hash(model_name: str, revision: str | None = None) -> str
     fallback so callers can proceed; the cache key won't auto-invalidate on
     upstream changes in that case.
     """
+    from huggingface_hub import constants
+    from huggingface_hub.file_download import repo_folder_name
+
     rev = revision or "main"
     if len(rev) == _HF_COMMIT_SHA_LENGTH and all(c in "0123456789abcdef" for c in rev.lower()):
         return rev
+
+    # When offline, skip the network call entirely and read the SHA from the
+    # local HF cache ref file ($HF_HUB_CACHE/<repo_folder>/refs/<rev>).
+    # This file is written by huggingface_hub on every successful download and
+    # contains exactly the remote commit SHA, so the key stays stable and
+    # identical to what the online path would return.
+    if constants.HF_HUB_OFFLINE:
+        ref_path = Path(constants.HF_HUB_CACHE) / repo_folder_name(repo_id=model_name, repo_type="model") / "refs" / rev
+        if ref_path.is_file():
+            return ref_path.read_text().strip()
+        logger.debug(
+            "Offline: no cached ref file for %s@%s; using revision string for cache key.",
+            model_name,
+            rev,
+        )
+        return rev
+
     try:
         commit_hash = huggingface_hub.model_info(model_name, revision=rev).sha
     except Exception as exc:  # noqa: BLE001
@@ -133,6 +153,7 @@ class SentenceTransformerEmbeddingBackend(BaseEmbeddingBackend):
         hasher = Hasher()
         if not Path(self.config.model_name).exists():
             commit_hash = _get_latest_commit_hash(self.config.model_name, self.config.revision)
+            hasher.update(self.config.model_name)
             hasher.update(commit_hash)
         else:
             model = self._load_model()

--- a/tests/embedder/test_hash.py
+++ b/tests/embedder/test_hash.py
@@ -78,12 +78,15 @@ class TestSentenceTransformerHashSpecific:
 class TestOfflineEmbedderCacheKey:
     """Regression tests for offline embedding cache key correctness (issue #321)."""
 
-    def test_no_cross_model_collision_offline(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_no_cross_model_collision_offline(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """Two different models with the same non-SHA revision must not collide when offline.
 
         Pre-fix: both fall back to the same revision string ("main") -> identical hashes.
         Post-fix: model_name is included in the hash -> distinct hashes.
         """
+        # Isolate the HF cache to an empty tmp dir so neither model resolves a local
+        # ref file (both degrade to the "main" revision string), keeping the test hermetic.
+        monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
         monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_OFFLINE", True)
         _get_latest_commit_hash.cache_clear()
 

--- a/tests/embedder/test_hash.py
+++ b/tests/embedder/test_hash.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import huggingface_hub
+import huggingface_hub.constants
 import pytest
 
 from autointent import Embedder
+from autointent._wrappers.embedder.sentence_transformers import _get_latest_commit_hash
 from autointent.configs import SentenceTransformerEmbeddingConfig, TokenizerConfig
 
 from .conftest import backend_configs
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from autointent.configs import EmbedderConfig
 
 
@@ -68,3 +73,77 @@ class TestSentenceTransformerHashSpecific:
 
         # Different models should produce different hashes
         assert embedder1._get_hash() != embedder2._get_hash()
+
+
+class TestOfflineEmbedderCacheKey:
+    """Regression tests for offline embedding cache key correctness (issue #321)."""
+
+    def test_no_cross_model_collision_offline(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Two different models with the same non-SHA revision must not collide when offline.
+
+        Pre-fix: both fall back to the same revision string ("main") -> identical hashes.
+        Post-fix: model_name is included in the hash -> distinct hashes.
+        """
+        monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_OFFLINE", True)
+        _get_latest_commit_hash.cache_clear()
+
+        config1 = SentenceTransformerEmbeddingConfig(model_name="org-a/model-alpha", revision="main", use_cache=False)
+        config2 = SentenceTransformerEmbeddingConfig(model_name="org-b/model-beta", revision="main", use_cache=False)
+
+        from autointent._wrappers.embedder.sentence_transformers import SentenceTransformerEmbeddingBackend
+
+        backend1 = SentenceTransformerEmbeddingBackend(config1)
+        backend2 = SentenceTransformerEmbeddingBackend(config2)
+
+        assert backend1.get_hash() != backend2.get_hash()
+
+        _get_latest_commit_hash.cache_clear()
+
+    def test_offline_local_ref_resolution(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """When offline and the HF cache contains refs/main, return the cached SHA without network.
+
+        Verifies that _get_latest_commit_hash reads from the local ref file instead of
+        calling model_info (which would raise under offline mode).
+        """
+        fake_sha = "a" * 40
+        model_name = "some-org/some-model"
+
+        from huggingface_hub.file_download import repo_folder_name
+
+        repo_folder = repo_folder_name(repo_id=model_name, repo_type="model")
+        ref_file = tmp_path / repo_folder / "refs" / "main"
+        ref_file.parent.mkdir(parents=True)
+        ref_file.write_text(fake_sha)
+
+        monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_OFFLINE", True)
+
+        # model_info must NOT be called — raise if it is
+        def _no_network(*args: object, **kwargs: object) -> None:
+            msg = "model_info called despite HF_HUB_OFFLINE=True"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(huggingface_hub, "model_info", _no_network)
+        _get_latest_commit_hash.cache_clear()
+
+        result = _get_latest_commit_hash(model_name, "main")
+        assert result == fake_sha
+
+        _get_latest_commit_hash.cache_clear()
+
+    def test_offline_missing_ref_returns_revision(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """When offline and no cached ref file exists, return the revision string without raising."""
+        monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_OFFLINE", True)
+
+        def _no_network(*args: object, **kwargs: object) -> None:
+            msg = "model_info called despite HF_HUB_OFFLINE=True"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(huggingface_hub, "model_info", _no_network)
+        _get_latest_commit_hash.cache_clear()
+
+        result = _get_latest_commit_hash("no-org/no-model", "main")
+        assert result == "main"
+
+        _get_latest_commit_hash.cache_clear()


### PR DESCRIPTION
## Summary
Fixes #321 (description + comment). Two complementary fixes to the embedder cache key in `sentence_transformers.py`:

1. **Cross-model collision (the dangerous one, from the issue comment):** `get_hash()` hashed only the resolved commit hash + `max_length`, never `model_name`. Offline, two different models both degrade to the revision string `"main"` → identical key → one served the other's embeddings (wrong data). Now `model_name` is hashed in the remote-model branch (not the trained/local-path branch, which uses an ephemeral tempdir path), so distinct models can never collide even when the SHA can't be resolved.
2. **Offline network call + warning + staleness:** under `HF_HUB_OFFLINE`, `_get_latest_commit_hash` now resolves the SHA from the local HF cache ref file (`$HF_HUB_CACHE/<repo_folder>/refs/<rev>`) instead of calling `model_info`. This removes the spurious per-cold-model warning and keeps the key stable/auto-invalidating offline, identical to the online path. The online path is unchanged; the missing-ref fallback is demoted to DEBUG.

Note: common models pinned in `DEFAULT_REVISIONS` already short-circuit on a SHA; these bugs bite non-pinned models or explicitly-set non-SHA revisions.

## Test plan
- [x] New tests in `tests/embedder/test_hash.py`: cross-model no-collision offline; offline local-ref resolution (asserts `model_info` not called); missing-ref fallback. All network-free, no model loads, with `lru_cache` cleared and `HF_HUB_CACHE` isolated to tmp.
- [x] Verified fail→pass via standalone snippets; HF APIs confirmed against `huggingface_hub` 0.36.2; ruff + mypy clean.
- [x] CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)