### PR TITLE
fix(pipeline): write inference_config.yaml with yaml.safe_dump so tuple-valued config fields reload

### DIFF
--- a/src/autointent/_pipeline/_pipeline.py
+++ b/src/autointent/_pipeline/_pipeline.py
@@ -311,7 +311,7 @@ class Pipeline:
 
         inference_nodes_configs = [cfg.asdict() for cfg in self._nodes_configs.values()]
         with (path / "inference_config.yaml").open("w") as file:
-            yaml.dump(inference_nodes_configs, file)
+            yaml.safe_dump(inference_nodes_configs, file)
 
     def validate_modules(self, dataset: Dataset, mode: SearchSpaceValidationMode) -> None:
         """Validate modules with dataset.

--- a/src/autointent/context/_context.py
+++ b/src/autointent/context/_context.py
@@ -125,7 +125,7 @@ class Context:
         inference_config = self.optimization_info.get_inference_nodes_config(asdict=True)
         inference_config_path = logs_dir / "inference_config.yaml"
         with inference_config_path.open("w") as file:
-            yaml.dump(inference_config, file)
+            yaml.safe_dump(inference_config, file)
 
     def load_optimization_info(self) -> None:
         """Restore the context state to resume the optimization process.

--- a/tests/pipeline/test_inference.py
+++ b/tests/pipeline/test_inference.py
@@ -7,7 +7,7 @@ import pytest
 from autointent import Pipeline
 from autointent.configs import LoggingConfig, TokenizerConfig, get_default_embedder_config
 from autointent.custom_types import NodeType
-from tests.conftest import apply_test_models, get_search_space
+from tests.conftest import apply_test_models, get_search_space, get_test_embedder_config
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -170,6 +170,39 @@ def test_load_with_overrided_params(dataset: Dataset, tmp_path: Path) -> None:
     # reason: deliberate escape for private state access
     loaded_scoring_module: Any = cast("Any", loaded_pipe.nodes[NodeType.scoring]).module
     assert loaded_scoring_module._embedder.config.tokenizer_config.max_length == 8
+
+
+def test_dump_load_with_tuple_valued_embedder_config(dataset: Dataset, project_dir: Path) -> None:
+    """HashingVectorizer's `ngram_range` is a `tuple[int, int]`; dumped pipelines must reload (#342, side finding 1)."""
+    search_space: list[dict[str, Any]] = [
+        {
+            "node_type": "scoring",
+            "target_metric": "scoring_f1",
+            "search_space": [{"module_name": "knn", "k": [3], "weights": ["distance"]}],
+        },
+        {
+            "node_type": "decision",
+            "target_metric": "decision_accuracy",
+            "search_space": [{"module_name": "argmax"}],
+        },
+    ]
+    pipeline_optimizer = Pipeline.from_search_space(search_space)
+    pipeline_optimizer.set_config(get_test_embedder_config())
+    logging_config = LoggingConfig(project_dir=project_dir, dump_modules=True, clear_ram=False)
+    pipeline_optimizer.set_config(logging_config)
+
+    context = pipeline_optimizer.fit(dataset)
+    utterances = ["123", "hello world"]
+
+    context.dump()
+    loaded_from_context_dump = Pipeline.load(logging_config.dirpath)
+    prediction = loaded_from_context_dump.predict(utterances)
+    assert len(prediction) == len(utterances)
+
+    dump_dir = project_dir / "dumped_pipeline"
+    pipeline_optimizer.dump(dump_dir)
+    loaded_from_pipeline_dump = Pipeline.load(dump_dir)
+    assert loaded_from_pipeline_dump.predict(utterances) == prediction
 
 
 def test_no_saving(dataset: Dataset, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes side finding 1 of #342: pipelines with a tuple-valued config field could not be reloaded.

`Pipeline.dump` (`_pipeline.py:314`) and `Context.dump` (`_context.py:128`) wrote `inference_config.yaml` with `yaml.dump`, which emits Python-specific tags for tuples:

```yaml
      ngram_range: !!python/tuple
      - 1
      - 2
```

while `Pipeline.load` (`_pipeline.py:352`) reads the file with `yaml.safe_load`, which raises:

```
yaml.constructor.ConstructorError: could not determine a constructor for the tag
'tag:yaml.org,2002:python/tuple'
```

`HashingVectorizerEmbeddingConfig.ngram_range` is a `tuple[int, int]` and travels into the yaml via `module_config["embedder_config"]` (`KNNScorer.get_implicit_initialization_params` uses python-mode `model_dump()`), so any pipeline using the hashing-vectorizer embedder — the config whose docstring recommends it for testing — was broken end-to-end. Existing round-trip tests didn't catch it because `apply_test_models` retargets to tiny sentence-transformer models, which have no tuple-valued fields.

## Fix

Switch both write sites to `yaml.safe_dump`. `SafeDumper` serializes tuples as plain YAML sequences, `safe_load` reads them back as lists, and pydantic coerces the lists to `tuple[int, int]` at config validation. As a bonus, `safe_dump` fails loudly at *dump* time on any future non-serializable config value instead of producing a file that only explodes at load time.

## Test

`test_dump_load_with_tuple_valued_embedder_config`: fit a minimal knn+argmax pipeline with `HashingVectorizerEmbeddingConfig`, then round-trip through both dump paths (`Context.dump` → `Pipeline.load` and `Pipeline.dump` → `Pipeline.load`) and check predictions. Verified failing with the `ConstructorError` above before the fix, passing after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
