### PR TITLE
fix(vector-index): split reset() from clear_ram(); restore fit-replaces for OpenSearch (#342)

### DIFF
--- a/src/autointent/_wrappers/vector_index/base_backend.py
+++ b/src/autointent/_wrappers/vector_index/base_backend.py
@@ -21,8 +21,11 @@ class BaseIndexBackend(ABC):
     def add(self, embeddings: npt.NDArray[Any], documents: list[Document]) -> None:
         """Add documents and their embeddings to the index.
 
-        The first ``add()`` call on an instance replaces any pre-existing contents
-        of the underlying index (fit-replaces semantics); subsequent calls append.
+        The first ``add()`` call on a fresh instance must start from empty index
+        contents (fit-replaces semantics); subsequent calls append. Backends with
+        durable shared state (e.g. OpenSearch) satisfy this by resetting the
+        remote index on their first write; purely local backends (Faiss) satisfy
+        it by construction.
         """
 
     @abstractmethod

--- a/src/autointent/_wrappers/vector_index/base_backend.py
+++ b/src/autointent/_wrappers/vector_index/base_backend.py
@@ -18,10 +18,24 @@ class BaseIndexBackend(ABC):
     def __init__(self, config: VectorIndexConfig, vector_size: int) -> None: ...
 
     @abstractmethod
-    def add(self, embeddings: npt.NDArray[Any], documents: list[Document]) -> None: ...
+    def add(self, embeddings: npt.NDArray[Any], documents: list[Document]) -> None:
+        """Add documents and their embeddings to the index.
+
+        The first ``add()`` call on an instance replaces any pre-existing contents
+        of the underlying index (fit-replaces semantics); subsequent calls append.
+        """
 
     @abstractmethod
-    def clear_ram(self) -> None: ...
+    def clear_ram(self) -> None:
+        """Release local (in-process) resources held by the backend.
+
+        Must not destroy durable index state: after ``clear_ram()``, a backend
+        restored via ``load()`` from a previous ``dump()`` must still serve queries.
+        """
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Drop all indexed documents, including durable state shared across instances."""
 
     @abstractmethod
     def query(self, embedding: npt.NDArray[Any], k: int) -> tuple[npt.NDArray[Any], list[list[Document]]]:

--- a/src/autointent/_wrappers/vector_index/faiss.py
+++ b/src/autointent/_wrappers/vector_index/faiss.py
@@ -62,6 +62,11 @@ class FaissBackend(BaseIndexBackend):
     def clear_ram(self) -> None:
         self._index.reset()
 
+    def reset(self) -> None:
+        """Drop all indexed documents: the vectors and the documents store."""
+        self._index.reset()
+        self._documents.clear()
+
     def get_all_embeddings(self) -> NDArray[Any]:
         return np.asarray(self._index.reconstruct_n(0, self._index.ntotal))
 

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -193,6 +193,12 @@ class OpenSearchBackend(BaseIndexBackend):
 
             hits = response_item["hits"]["hits"]
 
+            if not hits:
+                msg = (
+                    f"OpenSearch index '{self.index_name}' returned no documents for a query. "
+                    "The index is empty: fit() was never called on it, or it was reset."
+                )
+                raise RuntimeError(msg)
             # Extract similarities (OpenSearch script_score returns exact similarity scores)
             similarities = np.array([hit["_score"] for hit in hits])
             cosine_similarities.append(similarities)

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -37,6 +37,7 @@ class OpenSearchBackend(BaseIndexBackend):
         self.config = config.model_copy()
         self._client = opensearchpy.OpenSearch(hosts=config.hosts, **config.init_kwargs)
         self._index_name = self.config.index_name
+        self._has_written = False
 
     @property
     def index_name(self) -> str:
@@ -94,7 +95,12 @@ class OpenSearchBackend(BaseIndexBackend):
             )
 
     def add(self, embeddings: NDArray[Any], documents: list[Document]) -> None:
-        """Add embeddings and documents to OpenSearch index."""
+        """Add embeddings and documents to OpenSearch index.
+
+        The first ``add()`` call on this instance replaces any pre-existing contents of
+        the remote index (fit-replaces semantics, see #342); subsequent calls append.
+        This also holds for instances restored via ``load()``.
+        """
         if len(embeddings) != len(documents):
             msg = f"Number of embeddings ({len(embeddings)}) must match number of documents ({len(documents)})"
             raise ValueError(msg)
@@ -122,6 +128,10 @@ class OpenSearchBackend(BaseIndexBackend):
             )
 
         self._init_index()
+
+        if not self._has_written:
+            self.reset()
+            self._has_written = True
 
         # Use bulk API for efficient indexing
         try:

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -84,6 +84,15 @@ class OpenSearchBackend(BaseIndexBackend):
                 refresh=True,
             )
 
+    def reset(self) -> None:
+        """Drop all documents from the remote index (durable state)."""
+        if self._client.indices.exists(index=self.index_name):
+            self._client.delete_by_query(
+                index=self.index_name,
+                body={"query": {"match_all": {}}},
+                refresh=True,
+            )
+
     def add(self, embeddings: NDArray[Any], documents: list[Document]) -> None:
         """Add embeddings and documents to OpenSearch index."""
         if len(embeddings) != len(documents):

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -131,7 +131,6 @@ class OpenSearchBackend(BaseIndexBackend):
 
         if not self._has_written:
             self.reset()
-            self._has_written = True
 
         # Use bulk API for efficient indexing
         try:
@@ -150,6 +149,8 @@ class OpenSearchBackend(BaseIndexBackend):
         # Refresh index to make documents searchable immediately
         # Note: For large datasets, consider batching refreshes or using refresh=wait_for in bulk operations
         self._client.indices.refresh(index=self.index_name)
+
+        self._has_written = True
 
     def query(self, embedding: NDArray[Any], k: int) -> tuple[NDArray[Any], list[list[Document]]]:
         """Query the index using exact vector similarity search with script scoring."""

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -77,13 +77,12 @@ class OpenSearchBackend(BaseIndexBackend):
             self._client.indices.create(index=self.index_name, body=index_body)
 
     def clear_ram(self) -> None:
-        """Clear the index by deleting all documents."""
-        if self._client.indices.exists(index=self.index_name):
-            self._client.delete_by_query(
-                index=self.index_name,
-                body={"query": {"match_all": {}}},
-                refresh=True,
-            )
+        """Release local resources (none held): documents live in the remote index and are not touched.
+
+        Deleting remote documents here would destroy the durable state that ``dump()``
+        only references — the dumped pipeline would reload an empty index (#342).
+        Use :meth:`reset` to actually drop index contents.
+        """
 
     def reset(self) -> None:
         """Drop all documents from the remote index (durable state)."""

--- a/src/autointent/_wrappers/vector_index/vector_index.py
+++ b/src/autointent/_wrappers/vector_index/vector_index.py
@@ -82,6 +82,11 @@ class VectorIndex:
     def add(self, texts: list[str], labels: ListOfLabels) -> None:
         """Add texts and their corresponding labels to the index.
 
+        The first ``add()`` call creates the backend; per the backend contract, a fresh
+        backend's first write starts from empty index contents (fit-replaces semantics) —
+        for OpenSearch this clears any pre-existing documents in the configured index.
+        Subsequent calls append.
+
         Args:
             texts: List of input texts.
             labels: List of labels corresponding to the texts.

--- a/src/autointent/configs/_vector_index.py
+++ b/src/autointent/configs/_vector_index.py
@@ -17,7 +17,16 @@ class OpenSearchHost(TypedDict):
 
 class OpenSearchConfig(VectorIndexConfig):
     hosts: list[OpenSearchHost]
-    index_name: str | None = None
+    index_name: str | None = Field(
+        None,
+        description=(
+            "Name of the OpenSearch index. AutoIntent takes ownership of this index during fit(): "
+            "the first write of each fit clears its contents (fit-replaces semantics), so do not "
+            "point it at a collection you want to keep. To query an existing collection without "
+            "modifying it, use a loaded pipeline (load() + predict only). If None, a name is "
+            "derived from the first document added."
+        ),
+    )
     init_kwargs: dict[str, Any] = Field(default_factory=dict)  # TODO define set of options
 
 

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -398,3 +398,18 @@ class TestVectorIndexEdgeCases:
         finally:
             # Restore original modules
             sys.modules.update(original_modules)
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_empty_index_query_raises_actionable_error(opensearch_container: tuple[str, int]) -> None:
+    """Querying an empty index names the problem instead of failing later with a numpy cast error (issue #342)."""
+    host, port = opensearch_container
+    config = OpenSearchConfig(
+        hosts=[{"host": host, "port": port}],
+        index_name=f"test_empty_{uuid.uuid4().hex[:8]}",
+    )
+    backend = OpenSearchBackend(config=config, vector_size=8)
+    backend._init_index()
+
+    with pytest.raises(RuntimeError, match="empty"):
+        backend.query(np.zeros((1, 8)), k=3)

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 
 from autointent import VectorIndex
+from autointent._wrappers.vector_index.faiss import FaissBackend
 from autointent._wrappers.vector_index.opensearch import OpenSearchBackend
 from autointent.configs import (
     FaissConfig,
@@ -224,6 +225,19 @@ class TestVectorIndex:
             assert hasattr(vector_index, "index")
             embeddings = vector_index.get_all_embeddings()
             assert embeddings.shape[0] == 0
+
+    def test_reset_drops_all_documents(
+        self, vector_index: VectorIndex, sample_texts: list[str], sample_labels: list[int]
+    ) -> None:
+        """reset() drops every indexed document, including durable state (issue #342)."""
+        vector_index.add(sample_texts, sample_labels)
+
+        vector_index.index.reset()
+
+        assert vector_index.get_all_embeddings().shape[0] == 0
+        if isinstance(vector_index.index, FaissBackend):
+            # reset() must clear the documents store too, not only the vectors
+            assert vector_index.index._documents == []
 
     def test_dump_and_load(self, vector_index: VectorIndex, sample_texts: list[str], sample_labels: list[int]) -> None:
         """Test dumping and loading the vector index."""

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -231,20 +231,35 @@ class TestVectorIndex:
             assert len(documents[0]) <= 1
 
     def test_clear_ram(self, vector_index: VectorIndex, sample_texts: list[str], sample_labels: list[int]) -> None:
-        """Test clearing the index from RAM."""
+        """clear_ram() releases local resources and must not destroy durable state (issue #342)."""
         vector_index.add(sample_texts, sample_labels)
 
-        # Clear RAM
         vector_index.clear_ram()
 
-        # For FaissBackend, index should be reset
-        # For OpenSearchBackend, documents should be deleted
-        # Both should handle this gracefully
         if isinstance(vector_index.config, FaissConfig):
-            # Faiss index should be reset but still exist
-            assert hasattr(vector_index, "index")
-            embeddings = vector_index.get_all_embeddings()
-            assert embeddings.shape[0] == 0
+            # everything is local: the in-RAM vectors are dropped
+            assert vector_index.get_all_embeddings().shape[0] == 0
+        else:
+            # documents live remotely; releasing local resources must not delete them
+            assert vector_index.get_all_embeddings().shape[0] == len(sample_texts)
+
+    def test_dump_survives_clear_ram(
+        self,
+        vector_index: VectorIndex,
+        sample_texts: list[str],
+        sample_labels: list[int],
+        tmp_path: Path,
+    ) -> None:
+        """The optimizer dumps the best module, then clear_ram()s it; the dump must stay servable (issue #342)."""
+        vector_index.add(sample_texts, sample_labels)
+        dump_dir = tmp_path / "dump"
+        vector_index.dump(dump_dir)
+
+        vector_index.clear_ram()
+
+        loaded = VectorIndex.load(dump_dir)
+        _distances, documents = loaded.query(["password reset"], k=2)
+        assert len(documents[0]) == 2
 
     def test_reset_drops_all_documents(
         self, vector_index: VectorIndex, sample_texts: list[str], sample_labels: list[int]

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -144,6 +144,26 @@ class TestVectorIndex:
         embeddings = vector_index.get_all_embeddings()
         assert embeddings.shape[0] == 4
 
+    def test_first_add_of_new_instance_replaces_index_contents(
+        self,
+        vector_index: VectorIndex,
+        embedder_config: HashingVectorizerEmbeddingConfig,
+        sample_texts: list[str],
+        sample_labels: list[int],
+    ) -> None:
+        """A fresh instance's first add() starts from an empty index (issue #342, CV fold isolation).
+
+        Mirrors cross-validation: each fold's fit() constructs a new VectorIndex over the
+        same backend config. The previous fold's documents must not survive into this one.
+        """
+        vector_index.add(sample_texts, sample_labels)
+
+        second_index = VectorIndex(embedder_config=embedder_config, config=vector_index.config)
+        fold_texts, fold_labels = sample_texts[1:4], sample_labels[1:4]
+        second_index.add(fold_texts, fold_labels)
+
+        assert second_index.get_all_embeddings().shape[0] == len(fold_texts)
+
     def test_query_by_text(self, vector_index: VectorIndex, sample_texts: list[str], sample_labels: list[int]) -> None:
         """Test querying the index with text."""
         vector_index.add(sample_texts, sample_labels)


### PR DESCRIPTION
Closes #342.

## What

- `BaseIndexBackend` contract split: `clear_ram()` releases local resources and must not destroy durable state; new `reset()` drops all indexed documents.
- `OpenSearchBackend.clear_ram()` is now a documented no-op — it used to `delete_by_query(match_all)` the durable index that `dump()` only references, so `LoggingConfig(clear_ram=True)` emptied the exact index the dumped pipeline serves (symptom 1).
- `OpenSearchBackend.add()` restores *fit-replaces*: the first confirmed write of each backend instance resets the shared index (the `_has_written` flag flips only after a successful bulk write, so a failed first write stays armed to reset on retry). Every `fit()` constructs a fresh backend, so CV folds/trials no longer accumulate documents and validation folds are no longer retrievable while being scored (symptom 2).
- `FaissBackend.reset()` also clears `_documents`, closing the latent index/documents misalignment.
- Querying an empty OpenSearch index now raises an actionable `RuntimeError` instead of a downstream numpy cast `TypeError`.

## Out of scope

- Serving-time dump-as-reference hazard: #343 (composes with this fix).
- `text` field has no `keyword` subfield — will file separately.

## Perf note

Under hold-out, trials previously overwrote documents in place; now each trial's first write does `delete_by_query` + full re-index of the train split. Correct, but more writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)