### PR TITLE
feat(vector-index): OpenSearch copy-on-dump into immutable generation indices (#343)

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -124,3 +124,44 @@ AutoIntent's design emphasizes modularity and extensibility:
    Framework can be extended with custom embedding models, scoring algorithms, and decision strategies while maintaining compatibility with the AutoML optimization pipeline.
 
 This modular design ensures that AutoIntent can evolve with advances in NLP research while maintaining stability and backward compatibility for existing users.
+
+Vector Index Lifecycle
+======================
+
+All vector-index backends follow one contract: the **live index a module fits into is
+transient training scratch**, owned by whichever instance is currently fitting (each
+``fit()`` replaces its contents); **durability comes from** ``dump()`` **artifacts**.
+During hyperparameter search only the best module of each node is dumped, and trials
+keep rewriting the scratch index after the best one — so never serve from the live
+index; serve from a loaded dump.
+
+How ``dump()`` achieves durability differs by backend:
+
+- **Faiss** writes a self-contained directory (documents + binary index).
+- **OpenSearch** performs *copy-on-dump*: the live index is copied server-side
+  (``_reindex``) into a write-blocked *generation* index named ``{base}-best-{id}``,
+  and the dump directory records it in ``remote_manifest.json``. The corpus never
+  leaves the cluster. ``Pipeline.load`` binds to that immutable generation, verifies
+  its identity, and never writes; it fails loudly if the generation was deleted or
+  recreated.
+
+Notes specific to the OpenSearch backend:
+
+- **Cleanup.** Delete dumps with :func:`autointent.remove_module_dump` — it removes
+  the referenced generation index from the cluster along with the directory. A plain
+  ``rm -rf`` strands the generation (recoverable: generations are pattern-named
+  ``*-best-*``, so ops can also enforce an ISM age policy). AutoIntent's optimizer
+  uses this helper automatically when a new best trial replaces the previous one, so
+  the steady-state cluster footprint is the live scratch index plus one generation
+  per node type.
+- **Portability.** A dumped OpenSearch pipeline is portable only as far as the
+  cluster: copying the dump directory to an environment that cannot reach the same
+  cluster carries a dangling reference. This is inherent to keeping the corpus in
+  the engine.
+- **Querying an existing collection.** Do not point ``OpenSearchConfig.index_name``
+  at a collection you want to keep — ``fit()`` clears it (fit-replaces). To serve an
+  existing corpus read-only, fit and dump once, then use ``Pipeline.load`` +
+  ``predict``: loaded pipelines only ever read their immutable generation.
+- **Parallel trials.** Hyperparameter search with ``n_jobs > 1`` would share one live
+  scratch index across concurrently fitting trials; keep ``n_jobs = 1`` when using
+  the OpenSearch backend.

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -128,45 +128,17 @@ This modular design ensures that AutoIntent can evolve with advances in NLP rese
 Vector Index Lifecycle
 ======================
 
-All vector-index backends follow one contract: the **live index a module fits into is
-transient training scratch**, owned by whichever instance is currently fitting (each
-``fit()`` replaces its contents); **durability comes from** ``dump()`` **artifacts**.
-During hyperparameter search only the best module of each node is dumped, and trials
-keep rewriting the scratch index after the best one — so never serve from the live
-index; serve from a loaded dump.
+All vector-index backends follow one contract: the **live index a module fits into is transient training scratch**, owned by whichever instance is currently fitting (each ``fit()`` replaces its contents); **durability comes from** ``dump()`` **artifacts**. During hyperparameter search only the best module of each node is dumped, and trials keep rewriting the scratch index after the best one — so never serve from the live index; serve from a loaded dump.
 
 How ``dump()`` achieves durability differs by backend:
 
 - **Faiss** writes a self-contained directory (documents + binary index).
-- **OpenSearch** performs *copy-on-dump*: the live index is copied server-side
-  (``_reindex``) into a write-blocked *generation* index named ``{base}-best-{id}``,
-  and the dump directory records it in ``remote_manifest.json``. The corpus never
-  leaves the cluster. ``Pipeline.load`` binds to that immutable generation, verifies
-  its identity, and never writes; it fails loudly if the generation was deleted or
-  recreated.
+- **OpenSearch** performs *copy-on-dump*: the live index is copied server-side (``_reindex``) into a write-blocked *generation* index named ``{base}-best-{id}``, and the dump directory records it in ``remote_manifest.json``. The corpus never leaves the cluster. ``Pipeline.load`` binds to that immutable generation, verifies its identity, and never writes; it fails loudly if the generation was deleted or recreated.
 
 Notes specific to the OpenSearch backend:
 
-- **Cleanup.** Delete dumps with :func:`autointent.remove_module_dump` — it removes
-  the referenced generation index from the cluster along with the directory. A plain
-  ``rm -rf`` strands the generation (recoverable: generations are pattern-named
-  ``*-best-*``, so ops can also enforce an ISM age policy). AutoIntent's optimizer
-  uses this helper automatically when a new best trial replaces the previous one, so
-  during optimization the steady-state cluster footprint is the live scratch index
-  plus one generation per node type; a later ``Pipeline.dump()`` re-dump of an
-  already-optimized pipeline adds one more generation per node, which lingers until
-  the corresponding dump directory is deleted.
-- **Naming.** Avoid naming your own live indices with a ``-best-`` infix —
-  ``{base}-best-*`` is the namespace AutoIntent uses for generations and the serving
-  alias.
-- **Portability.** A dumped OpenSearch pipeline is portable only as far as the
-  cluster: copying the dump directory to an environment that cannot reach the same
-  cluster carries a dangling reference. This is inherent to keeping the corpus in
-  the engine.
-- **Querying an existing collection.** Do not point ``OpenSearchConfig.index_name``
-  at a collection you want to keep — ``fit()`` clears it (fit-replaces). To serve an
-  existing corpus read-only, fit and dump once, then use ``Pipeline.load`` +
-  ``predict``: loaded pipelines only ever read their immutable generation.
-- **Parallel trials.** Hyperparameter search with ``n_jobs > 1`` would share one live
-  scratch index across concurrently fitting trials; keep ``n_jobs = 1`` when using
-  the OpenSearch backend.
+- **Cleanup.** Delete dumps with :func:`autointent.remove_module_dump` — it removes the referenced generation index from the cluster along with the directory. A plain ``rm -rf`` strands the generation (recoverable: generations are pattern-named ``*-best-*``, so ops can also enforce an ISM age policy). AutoIntent's optimizer uses this helper automatically when a new best trial replaces the previous one, so during optimization the steady-state cluster footprint is the live scratch index plus one generation per node type; a later ``Pipeline.dump()`` re-dump of an already-optimized pipeline adds one more generation per node, which lingers until the corresponding dump directory is deleted.
+- **Naming.** Avoid naming your own live indices with a ``-best-`` infix — ``{base}-best-*`` is the namespace AutoIntent uses for generations and the serving alias.
+- **Portability.** A dumped OpenSearch pipeline is portable only as far as the cluster: copying the dump directory to an environment that cannot reach the same cluster carries a dangling reference. This is inherent to keeping the corpus in the engine.
+- **Querying an existing collection.** Do not point ``OpenSearchConfig.index_name`` at a collection you want to keep — ``fit()`` clears it (fit-replaces). To serve an existing corpus read-only, fit and dump once, then use ``Pipeline.load`` + ``predict``: loaded pipelines only ever read their immutable generation.
+- **Parallel trials.** Hyperparameter search with ``n_jobs > 1`` would share one live scratch index across concurrently fitting trials; keep ``n_jobs = 1`` when using the OpenSearch backend.

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -152,8 +152,13 @@ Notes specific to the OpenSearch backend:
   ``rm -rf`` strands the generation (recoverable: generations are pattern-named
   ``*-best-*``, so ops can also enforce an ISM age policy). AutoIntent's optimizer
   uses this helper automatically when a new best trial replaces the previous one, so
-  the steady-state cluster footprint is the live scratch index plus one generation
-  per node type.
+  during optimization the steady-state cluster footprint is the live scratch index
+  plus one generation per node type; a later ``Pipeline.dump()`` re-dump of an
+  already-optimized pipeline adds one more generation per node, which lingers until
+  the corresponding dump directory is deleted.
+- **Naming.** Avoid naming your own live indices with a ``-best-`` infix —
+  ``{base}-best-*`` is the namespace AutoIntent uses for generations and the serving
+  alias.
 - **Portability.** A dumped OpenSearch pipeline is portable only as far as the
   cluster: copying the dump directory to an environment that cannot reach the same
   cluster carries a dangling reference. This is inherent to keeping the corpus in

--- a/src/autointent/__init__.py
+++ b/src/autointent/__init__.py
@@ -1,7 +1,7 @@
 """This is AutoIntent API reference."""
 
 from ._logging import setup_logging
-from ._wrappers import Ranker, Embedder, VectorIndex
+from ._wrappers import Ranker, Embedder, VectorIndex, remove_module_dump
 from ._dataset import Dataset
 from ._hash import Hasher
 from .context import Context, load_dataset
@@ -19,5 +19,6 @@ __all__ = [
     "Ranker",
     "VectorIndex",
     "load_dataset",
+    "remove_module_dump",
     "setup_logging",
 ]

--- a/src/autointent/_utils.py
+++ b/src/autointent/_utils.py
@@ -25,5 +25,3 @@ def detect_device() -> str:
     if torch.mps.is_available():
         return "mps"
     return "cpu"
-
-

--- a/src/autointent/_wrappers/__init__.py
+++ b/src/autointent/_wrappers/__init__.py
@@ -1,7 +1,7 @@
 from .ranker import Ranker
 from .embedder import Embedder
-from .vector_index import VectorIndex
+from .vector_index import VectorIndex, remove_module_dump
 from .base_torch_module import BaseTorchModuleWithVocab
 from .base_torch_module import BaseTorchModule
 
-__all__ = ["BaseTorchModule", "BaseTorchModuleWithVocab", "Embedder", "Ranker", "VectorIndex"]
+__all__ = ["BaseTorchModule", "BaseTorchModuleWithVocab", "Embedder", "Ranker", "VectorIndex", "remove_module_dump"]

--- a/src/autointent/_wrappers/vector_index/__init__.py
+++ b/src/autointent/_wrappers/vector_index/__init__.py
@@ -1,3 +1,4 @@
+from .remote_dumps import remove_module_dump
 from .vector_index import VectorIndex
 
-__all__ = ["VectorIndex"]
+__all__ = ["VectorIndex", "remove_module_dump"]

--- a/src/autointent/_wrappers/vector_index/base_backend.py
+++ b/src/autointent/_wrappers/vector_index/base_backend.py
@@ -13,6 +13,16 @@ if TYPE_CHECKING:
     from autointent.custom_types import Document
 
 
+MANIFEST_FILENAME = "remote_manifest.json"
+"""Marker file inside a dump directory: the dump references remote cluster state.
+
+Any backend whose ``dump()`` leaves data in an external engine writes this file
+(``{"engine": ..., "index": ..., "dump_id": ...}``) so that dump-deletion tooling
+can clean up the referenced cluster index (see ``remote_dumps.remove_module_dump``).
+"""
+
+
+
 class BaseIndexBackend(ABC):
     @abstractmethod
     def __init__(self, config: VectorIndexConfig, vector_size: int) -> None: ...

--- a/src/autointent/_wrappers/vector_index/base_backend.py
+++ b/src/autointent/_wrappers/vector_index/base_backend.py
@@ -22,7 +22,6 @@ can clean up the referenced cluster index (see ``remote_dumps.remove_module_dump
 """
 
 
-
 class BaseIndexBackend(ABC):
     @abstractmethod
     def __init__(self, config: VectorIndexConfig, vector_size: int) -> None: ...

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -43,6 +43,8 @@ class OpenSearchBackend(BaseIndexBackend):
         self._client = opensearchpy.OpenSearch(hosts=config.hosts, **config.init_kwargs)
         self._index_name = self.config.index_name
         self._has_written = False
+        self._generation_index: str | None = None
+        self._read_only = False
 
     @property
     def index_name(self) -> str:
@@ -257,7 +259,6 @@ class OpenSearchBackend(BaseIndexBackend):
             self._client.clear_scroll(scroll_id=scroll_id)
 
         return np.array(embeddings)
-
 
     def _copy_index(self, source: str, dest: str) -> None:
         """Server-side copy: data moves shard-to-shard inside the cluster, never through the client.

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -169,6 +169,7 @@ class OpenSearchBackend(BaseIndexBackend):
         self._client.indices.refresh(index=self.index_name)
 
         self._has_written = True
+        self._generation_index = None  # the live index is the source of truth again
 
     def query(self, embedding: NDArray[Any], k: int) -> tuple[NDArray[Any], list[list[Document]]]:
         """Query the index using exact vector similarity search with script scoring."""
@@ -355,13 +356,20 @@ class OpenSearchBackend(BaseIndexBackend):
         """
         path.mkdir(parents=True, exist_ok=True)
 
+        manifest_path = path / self._manifest_filename
+        old_manifest: dict[str, Any] | None = None
+        if manifest_path.exists():
+            with manifest_path.open("r", encoding="utf-8") as file:
+                old_manifest = json.load(file)
+
         manifest: dict[str, Any] | None = None
         if self._index_name is not None:
             dump_id = uuid.uuid4().hex[:12]
             base = self.index_name.split("-best-")[0]
             generation = f"{base}-best-{dump_id}"
             self._client.indices.create(index=generation, body=self._index_body(dump_id))
-            self._copy_index(source=self.index_name, dest=generation)
+            source = self._generation_index or self.index_name
+            self._copy_index(source=source, dest=generation)
             self._client.indices.put_settings(index=generation, body={"index": {"blocks": {"write": True}}})
             self._generation_index = generation
             manifest = {"engine": "opensearch", "index": generation, "dump_id": dump_id}
@@ -373,8 +381,13 @@ class OpenSearchBackend(BaseIndexBackend):
             file.write(str(self.vector_size))
 
         if manifest is not None:
-            with (path / self._manifest_filename).open("w", encoding="utf-8") as file:
+            with manifest_path.open("w", encoding="utf-8") as file:
                 json.dump(manifest, file, indent=4, ensure_ascii=False)
+        elif old_manifest is not None:
+            manifest_path.unlink()
+
+        if old_manifest is not None and (manifest is None or old_manifest["index"] != manifest["index"]):
+            self._delete_generation(self._client, old_manifest)
 
     @classmethod
     def load(cls, path: Path) -> Self:

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -292,6 +292,23 @@ class OpenSearchBackend(BaseIndexBackend):
             raise RuntimeError(msg)
         self._client.indices.refresh(index=dest)
 
+    def _swap_serving_alias(self, base: str, generation: str) -> None:
+        """Point the ``{base}-best`` alias at the new generation, best-effort.
+
+        Nothing in the library consumes this alias — it exists purely as an operator
+        convenience for querying "whatever is currently served" from outside AutoIntent.
+        A failure here (e.g. a naming conflict with a real index) must not fail the dump.
+        """
+        alias = f"{base}-best"
+        try:
+            actions: list[dict[str, Any]] = [{"add": {"index": generation, "alias": alias}}]
+            existing = self._client.indices.get_alias(name=alias, ignore=404)
+            if isinstance(existing, dict) and "error" not in existing:
+                actions = [{"remove": {"index": index, "alias": alias}} for index in existing] + actions
+            self._client.indices.update_aliases(body={"actions": actions})  # remove+add is atomic
+        except Exception as exc:  # noqa: BLE001 -- alias is operator convenience; dump must not fail on it
+            logger.warning("failed to update serving alias '%s' for generation '%s': %s", alias, generation, exc)
+
     def _bind_generation(self, generation: str, dump_id: str) -> None:
         """Bind this instance read-only to a dump generation, verifying it is intact."""
         stored: str | None = None
@@ -307,6 +324,21 @@ class OpenSearchBackend(BaseIndexBackend):
         self._index_name = generation
         self._generation_index = generation
         self._read_only = True
+
+    @classmethod
+    def _read_manifest(cls, path: Path) -> dict[str, str]:
+        """Read and validate ``remote_manifest.json`` at a dump directory.
+
+        Raises a specific, actionable error if the expected keys are missing or empty,
+        instead of letting callers fail later with an opaque ``KeyError``.
+        """
+        manifest_path = path / cls._manifest_filename
+        with manifest_path.open("r", encoding="utf-8") as file:
+            manifest: dict[str, str] = json.load(file)
+        if not manifest.get("index") or not manifest.get("dump_id"):
+            msg = f"dump manifest at '{manifest_path}' is malformed: expected keys 'index' and 'dump_id'"
+            raise RuntimeError(msg)
+        return manifest
 
     @classmethod
     def _delete_generation(cls, client: Any, manifest: dict[str, Any]) -> None:  # noqa: ANN401
@@ -331,8 +363,7 @@ class OpenSearchBackend(BaseIndexBackend):
         cluster and the index. Safe to call twice; refuses to delete an index whose
         ``_meta.dump_id`` no longer matches the manifest.
         """
-        with (path / cls._manifest_filename).open("r", encoding="utf-8") as file:
-            manifest = json.load(file)
+        manifest = cls._read_manifest(path)
         with (path / cls._config_filename).open("r", encoding="utf-8") as file:
             config = OpenSearchConfig.model_validate(json.load(file))
 
@@ -368,15 +399,17 @@ class OpenSearchBackend(BaseIndexBackend):
             base = self.index_name.split("-best-")[0]
             generation = f"{base}-best-{dump_id}"
             self._client.indices.create(index=generation, body=self._index_body(dump_id))
-            source = self._generation_index or self.index_name
-            self._copy_index(source=source, dest=generation)
-            self._client.indices.put_settings(index=generation, body={"index": {"blocks": {"write": True}}})
-            alias = f"{base}-best"
-            actions: list[dict[str, Any]] = [{"add": {"index": generation, "alias": alias}}]
-            existing = self._client.indices.get_alias(name=alias, ignore=404)
-            if isinstance(existing, dict) and "error" not in existing:
-                actions = [{"remove": {"index": index, "alias": alias}} for index in existing] + actions
-            self._client.indices.update_aliases(body={"actions": actions})  # remove+add is atomic
+            try:
+                source = self._generation_index or self.index_name
+                self._copy_index(source=source, dest=generation)
+                self._client.indices.put_settings(index=generation, body={"index": {"blocks": {"write": True}}})
+                self._swap_serving_alias(base=base, generation=generation)
+            except Exception:
+                try:
+                    self._client.indices.delete(index=generation)
+                except Exception:
+                    logger.exception("failed to delete partial generation '%s' after dump failure", generation)
+                raise
             self._generation_index = generation
             manifest = {"engine": "opensearch", "index": generation, "dump_id": dump_id}
 
@@ -414,7 +447,6 @@ class OpenSearchBackend(BaseIndexBackend):
 
         manifest_path = path / cls._manifest_filename
         if manifest_path.exists():
-            with manifest_path.open("r", encoding="utf-8") as file:
-                manifest = json.load(file)
+            manifest = cls._read_manifest(path)
             instance._bind_generation(manifest["index"], manifest["dump_id"])
         return instance

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from autointent._deps import require
 from autointent.configs import OpenSearchConfig
 from autointent.custom_types import Document
 
@@ -30,14 +31,10 @@ class OpenSearchBackend(BaseIndexBackend):
     _manifest_filename = MANIFEST_FILENAME
 
     def __init__(self, config: OpenSearchConfig, vector_size: int) -> None:
-        try:
-            import opensearchpy
+        require("opensearch")
+        import opensearchpy
 
-            self._opensearchpy = opensearchpy
-        except ImportError as e:
-            msg = "Unable to create OpenSearch vector index. Install opensearch-py python package first."
-            raise RuntimeError(msg) from e
-
+        self._opensearchpy = opensearchpy
         self.vector_size = vector_size
         self.config = config.model_copy()
         self._client = opensearchpy.OpenSearch(hosts=config.hosts, **config.init_kwargs)
@@ -367,11 +364,8 @@ class OpenSearchBackend(BaseIndexBackend):
         with (path / cls._config_filename).open("r", encoding="utf-8") as file:
             config = OpenSearchConfig.model_validate(json.load(file))
 
-        try:
-            import opensearchpy
-        except ImportError as e:  # same optional dependency story as __init__
-            msg = "Unable to delete OpenSearch dump generation. Install opensearch-py python package first."
-            raise RuntimeError(msg) from e
+        require("opensearch")
+        import opensearchpy
 
         client = opensearchpy.OpenSearch(hosts=config.hosts, **config.init_kwargs)
         cls._delete_generation(client, manifest)

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -307,6 +307,43 @@ class OpenSearchBackend(BaseIndexBackend):
         self._generation_index = generation
         self._read_only = True
 
+    @classmethod
+    def _delete_generation(cls, client: Any, manifest: dict[str, Any]) -> None:  # noqa: ANN401
+        """Delete the generation index a manifest references — only if we still own it."""
+        generation = manifest["index"]
+        if not client.indices.exists(index=generation):
+            return
+        mappings = client.indices.get_mapping(index=generation)[generation]["mappings"]
+        if mappings.get("_meta", {}).get("dump_id") != manifest["dump_id"]:
+            logger.warning(
+                "cluster index '%s' was recreated since this dump was written; leaving it in place",
+                generation,
+            )
+            return
+        client.indices.delete(index=generation)
+
+    @classmethod
+    def delete_dumped_generation(cls, path: Path) -> None:
+        """Delete the cluster-side generation referenced by the dump directory at ``path``.
+
+        Reads ``remote_manifest.json`` and ``config.json`` from ``path`` to locate the
+        cluster and the index. Safe to call twice; refuses to delete an index whose
+        ``_meta.dump_id`` no longer matches the manifest.
+        """
+        with (path / cls._manifest_filename).open("r", encoding="utf-8") as file:
+            manifest = json.load(file)
+        with (path / cls._config_filename).open("r", encoding="utf-8") as file:
+            config = OpenSearchConfig.model_validate(json.load(file))
+
+        try:
+            import opensearchpy
+        except ImportError as e:  # same optional dependency story as __init__
+            msg = "Unable to delete OpenSearch dump generation. Install opensearch-py python package first."
+            raise RuntimeError(msg) from e
+
+        client = opensearchpy.OpenSearch(hosts=config.hosts, **config.init_kwargs)
+        cls._delete_generation(client, manifest)
+
     def dump(self, path: Path) -> None:
         """Snapshot the index into an immutable cluster-side generation.
 

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -371,6 +371,12 @@ class OpenSearchBackend(BaseIndexBackend):
             source = self._generation_index or self.index_name
             self._copy_index(source=source, dest=generation)
             self._client.indices.put_settings(index=generation, body={"index": {"blocks": {"write": True}}})
+            alias = f"{base}-best"
+            actions: list[dict[str, Any]] = [{"add": {"index": generation, "alias": alias}}]
+            existing = self._client.indices.get_alias(name=alias, ignore=404)
+            if isinstance(existing, dict) and "error" not in existing:
+                actions = [{"remove": {"index": index, "alias": alias}} for index in existing] + actions
+            self._client.indices.update_aliases(body={"actions": actions})  # remove+add is atomic
             self._generation_index = generation
             manifest = {"engine": "opensearch", "index": generation, "dump_id": dump_id}
 

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
+import time
+import uuid
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -9,7 +12,7 @@ import numpy as np
 from autointent.configs import OpenSearchConfig
 from autointent.custom_types import Document
 
-from .base_backend import BaseIndexBackend
+from .base_backend import MANIFEST_FILENAME, BaseIndexBackend
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -18,11 +21,13 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
+logger = logging.getLogger(__name__)
+
+
 class OpenSearchBackend(BaseIndexBackend):
-    _documents_filename = "documents.json"
     _config_filename = "config.json"
-    _embeddings_filename = "embeddings.json"
     _vector_size_filename = "vector_size.txt"
+    _manifest_filename = MANIFEST_FILENAME
 
     def __init__(self, config: OpenSearchConfig, vector_size: int) -> None:
         try:
@@ -46,35 +51,40 @@ class OpenSearchBackend(BaseIndexBackend):
             raise RuntimeError(msg)
         return self._index_name
 
+    def _index_body(self, dump_id: str | None = None) -> dict[str, Any]:
+        """Index settings/mappings for exact vector search; optionally stamped with a dump identity."""
+        body: dict[str, Any] = {
+            "settings": {
+                "index": {
+                    "knn": False,  # Disable approximate kNN for exact search
+                    "number_of_shards": 1,
+                    "number_of_replicas": 0,
+                }
+            },
+            "mappings": {
+                "properties": {
+                    "values": {
+                        "type": "knn_vector",
+                        "dimension": self.vector_size,
+                        # No method specified - this enables exact search with script scoring
+                    },
+                    "text": {
+                        "type": "text",
+                        "analyzer": "standard",
+                    },
+                    "label": {
+                        "type": "keyword",
+                    },
+                }
+            },
+        }
+        if dump_id is not None:
+            body["mappings"]["_meta"] = {"dump_id": dump_id}
+        return body
+
     def _init_index(self) -> None:
         if not self._client.indices.exists(index=self.index_name):
-            # Create index for exact vector search using script scoring
-            index_body = {
-                "settings": {
-                    "index": {
-                        "knn": False,  # Disable approximate kNN for exact search
-                        "number_of_shards": 1,
-                        "number_of_replicas": 0,
-                    }
-                },
-                "mappings": {
-                    "properties": {
-                        "values": {
-                            "type": "knn_vector",
-                            "dimension": self.vector_size,
-                            # No method specified - this enables exact search with script scoring
-                        },
-                        "text": {
-                            "type": "text",
-                            "analyzer": "standard",
-                        },
-                        "label": {
-                            "type": "keyword",
-                        },
-                    }
-                },
-            }
-            self._client.indices.create(index=self.index_name, body=index_body)
+            self._client.indices.create(index=self.index_name, body=self._index_body())
 
     def clear_ram(self) -> None:
         """Release local resources (none held): documents live in the remote index and are not touched.
@@ -248,15 +258,62 @@ class OpenSearchBackend(BaseIndexBackend):
 
         return np.array(embeddings)
 
+
+    def _copy_index(self, source: str, dest: str) -> None:
+        """Server-side copy: data moves shard-to-shard inside the cluster, never through the client.
+
+        Polls the task API instead of ``wait_for_completion=true`` so arbitrarily large
+        corpora are not capped by the HTTP client timeout.
+        """
+        self._client.indices.refresh(index=source)
+        response = self._client.reindex(
+            body={"source": {"index": source}, "dest": {"index": dest}},
+            wait_for_completion=False,
+        )
+        task_id = response["task"]
+        while True:
+            status = self._client.tasks.get(task_id=task_id)
+            if status.get("completed"):
+                break
+            time.sleep(0.2)
+        error = status.get("error")
+        failures = status.get("response", {}).get("failures", [])
+        if error or failures:
+            msg = f"Server-side copy from '{source}' to '{dest}' failed: {error or failures}"
+            raise RuntimeError(msg)
+        self._client.indices.refresh(index=dest)
+
     def dump(self, path: Path) -> None:
-        """Save index data to files."""
+        """Snapshot the index into an immutable cluster-side generation.
+
+        Creates ``{base}-best-{uuid}`` with the same mapping as the live index, copies the
+        current contents into it server-side, write-blocks it, and records it in
+        ``remote_manifest.json`` so ``load()`` serves exactly the data present now — later
+        fits of the live index cannot change it (issue #343). If the instance was never
+        fitted, only the plain config reference is written.
+        """
         path.mkdir(parents=True, exist_ok=True)
+
+        manifest: dict[str, Any] | None = None
+        if self._index_name is not None:
+            dump_id = uuid.uuid4().hex[:12]
+            base = self.index_name.split("-best-")[0]
+            generation = f"{base}-best-{dump_id}"
+            self._client.indices.create(index=generation, body=self._index_body(dump_id))
+            self._copy_index(source=self.index_name, dest=generation)
+            self._client.indices.put_settings(index=generation, body={"index": {"blocks": {"write": True}}})
+            self._generation_index = generation
+            manifest = {"engine": "opensearch", "index": generation, "dump_id": dump_id}
 
         with (path / self._config_filename).open("w", encoding="utf-8") as file:
             json.dump(self.config.model_dump(), file, indent=4, ensure_ascii=False)
 
         with (path / self._vector_size_filename).open("w", encoding="utf-8") as file:
             file.write(str(self.vector_size))
+
+        if manifest is not None:
+            with (path / self._manifest_filename).open("w", encoding="utf-8") as file:
+                json.dump(manifest, file, indent=4, ensure_ascii=False)
 
     @classmethod
     def load(cls, path: Path) -> Self:

--- a/src/autointent/_wrappers/vector_index/opensearch.py
+++ b/src/autointent/_wrappers/vector_index/opensearch.py
@@ -112,6 +112,13 @@ class OpenSearchBackend(BaseIndexBackend):
         the remote index (fit-replaces semantics, see #342); subsequent calls append.
         This also holds for instances restored via ``load()``.
         """
+        if self._read_only:
+            msg = (
+                f"This instance was loaded from a dump and serves the immutable generation index "
+                f"'{self.index_name}'. Create a new backend (or re-fit the module) to write data."
+            )
+            raise RuntimeError(msg)
+
         if len(embeddings) != len(documents):
             msg = f"Number of embeddings ({len(embeddings)}) must match number of documents ({len(documents)})"
             raise ValueError(msg)
@@ -284,6 +291,22 @@ class OpenSearchBackend(BaseIndexBackend):
             raise RuntimeError(msg)
         self._client.indices.refresh(index=dest)
 
+    def _bind_generation(self, generation: str, dump_id: str) -> None:
+        """Bind this instance read-only to a dump generation, verifying it is intact."""
+        stored: str | None = None
+        if self._client.indices.exists(index=generation):
+            mappings = self._client.indices.get_mapping(index=generation)[generation]["mappings"]
+            stored = mappings.get("_meta", {}).get("dump_id")
+        if stored != dump_id:
+            msg = (
+                f"dump references cluster index '{generation}' which no longer exists or was recreated "
+                f"(expected dump_id={dump_id!r}, found {stored!r})"
+            )
+            raise RuntimeError(msg)
+        self._index_name = generation
+        self._generation_index = generation
+        self._read_only = True
+
     def dump(self, path: Path) -> None:
         """Snapshot the index into an immutable cluster-side generation.
 
@@ -318,7 +341,12 @@ class OpenSearchBackend(BaseIndexBackend):
 
     @classmethod
     def load(cls, path: Path) -> Self:
-        """Load index from saved files."""
+        """Load index from saved files.
+
+        If the dump carries a ``remote_manifest.json``, the instance binds read-only to the
+        immutable generation index recorded there (and verifies its identity). Dumps without
+        a manifest (pre-#343, or dumped before any fit) bind to the configured live index.
+        """
         with (path / cls._config_filename).open("r", encoding="utf-8") as file:
             config_data = json.load(file)
 
@@ -326,4 +354,11 @@ class OpenSearchBackend(BaseIndexBackend):
             vector_size = int(file.read())
 
         config = OpenSearchConfig.model_validate(config_data)
-        return cls(config=config, vector_size=vector_size)
+        instance = cls(config=config, vector_size=vector_size)
+
+        manifest_path = path / cls._manifest_filename
+        if manifest_path.exists():
+            with manifest_path.open("r", encoding="utf-8") as file:
+                manifest = json.load(file)
+            instance._bind_generation(manifest["index"], manifest["dump_id"])
+        return instance

--- a/src/autointent/_wrappers/vector_index/remote_dumps.py
+++ b/src/autointent/_wrappers/vector_index/remote_dumps.py
@@ -1,0 +1,46 @@
+"""Engine-agnostic deletion of dumps that reference remote cluster state (issue #343).
+
+A backend whose ``dump()`` leaves data in an external engine marks the dump with a
+``remote_manifest.json``. Deleting such a dump with a bare ``shutil.rmtree`` strands
+the referenced cluster index; :func:`remove_module_dump` deletes both.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+
+from .base_backend import MANIFEST_FILENAME
+from .opensearch import OpenSearchBackend
+
+logger = logging.getLogger(__name__)
+
+
+def _delete_remote_index(manifest_path: Path) -> None:
+    """Best-effort deletion of the cluster index one manifest references."""
+    try:
+        with manifest_path.open("r", encoding="utf-8") as file:
+            engine = json.load(file).get("engine")
+        if engine == "opensearch":
+            OpenSearchBackend.delete_dumped_generation(manifest_path.parent)
+        else:
+            logger.warning("unknown remote dump engine %r in %s; skipping cluster cleanup", engine, manifest_path)
+    except Exception:
+        logger.exception("failed to delete remote index referenced by %s", manifest_path)
+
+
+def remove_module_dump(path: str | Path) -> None:
+    """Remove a module (or whole pipeline) dump directory together with its remote state.
+
+    Scans the tree for ``remote_manifest.json`` files, deletes each referenced cluster
+    index (any future remote backend that drops a manifest inherits this cleanup), then
+    removes the directory. Cleanup is best-effort: cluster errors are logged, not raised,
+    matching the ``shutil.rmtree(..., ignore_errors=True)`` this replaces in the
+    optimization loop. Dumps without manifests (Faiss, pre-#343) are simply removed.
+    """
+    path = Path(path)
+    for manifest_path in path.rglob(MANIFEST_FILENAME):
+        _delete_remote_index(manifest_path)
+    shutil.rmtree(path, ignore_errors=True)  # workaround for windows

--- a/src/autointent/configs/_vector_index.py
+++ b/src/autointent/configs/_vector_index.py
@@ -22,9 +22,10 @@ class OpenSearchConfig(VectorIndexConfig):
         description=(
             "Name of the OpenSearch index. AutoIntent takes ownership of this index during fit(): "
             "the first write of each fit clears its contents (fit-replaces semantics), so do not "
-            "point it at a collection you want to keep. To query an existing collection without "
-            "modifying it, use a loaded pipeline (load() + predict only). If None, a name is "
-            "derived from the first document added."
+            "point it at a collection you want to keep. It is training scratch — dump() copies its "
+            "contents into an immutable '{index_name}-best-*' generation index that loaded pipelines "
+            "serve from. To query an existing collection without modifying it, use a loaded pipeline "
+            "(load() + predict only). If None, a name is derived from the first document added."
         ),
     )
     init_kwargs: dict[str, Any] = Field(default_factory=dict)  # TODO define set of options

--- a/src/autointent/context/optimization_info/_optimization_info.py
+++ b/src/autointent/context/optimization_info/_optimization_info.py
@@ -37,6 +37,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _dump_dir_nonempty(path: str) -> bool:
+    """Whether a module dump directory exists and contains at least one entry."""
+    dump_path = Path(path)
+    return dump_path.is_dir() and any(dump_path.iterdir())
+
+
 @dataclass
 class ModulesList:
     """Container for managing the best module for each node type.
@@ -128,7 +134,14 @@ class OptimizationInfo:
             if old_best_metric_value_idx is not None:
                 prev_best_dump = self.trials.get_trials(node_type)[old_best_metric_value_idx].module_dump_dir
                 if prev_best_dump is not None:
-                    remove_module_dump(prev_best_dump)
+                    if module_dump_dir is not None and _dump_dir_nonempty(module_dump_dir):
+                        remove_module_dump(prev_best_dump)
+                    else:
+                        logger.warning(
+                            "keeping previous best dump %s: the new best trial's dump at %s was not produced",
+                            prev_best_dump,
+                            module_dump_dir,
+                        )
         else:
             module_dump_dir = None
 

--- a/src/autointent/context/optimization_info/_optimization_info.py
+++ b/src/autointent/context/optimization_info/_optimization_info.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from autointent._dump_tools import Dumper
+from autointent._wrappers.vector_index import remove_module_dump
 from autointent.configs import InferenceNodeConfig
 from autointent.custom_types import NodeType
 
@@ -127,7 +128,7 @@ class OptimizationInfo:
             if old_best_metric_value_idx is not None:
                 prev_best_dump = self.trials.get_trials(node_type)[old_best_metric_value_idx].module_dump_dir
                 if prev_best_dump is not None:
-                    shutil.rmtree(prev_best_dump, ignore_errors=True)  # workaround for windows
+                    remove_module_dump(prev_best_dump)
         else:
             module_dump_dir = None
 

--- a/tests/ci/test_compute_matrix.py
+++ b/tests/ci/test_compute_matrix.py
@@ -88,9 +88,7 @@ class TestMain:
         assert json.loads(outputs["matrix"]) == cm.FULL_MATRIX
         assert json.loads(outputs["warm_os"]) == ["ubuntu-latest", "windows-latest"]
 
-    def test_pr_without_label_writes_minimal_matrix(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    def test_pr_without_label_writes_minimal_matrix(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         out = tmp_path / "out.txt"
         monkeypatch.setenv("EVENT_NAME", "pull_request")
         monkeypatch.setenv("LABELS_JSON", '["bug"]')
@@ -103,9 +101,7 @@ class TestMain:
         assert json.loads(outputs["matrix"]) == cm.MINIMAL_MATRIX
         assert json.loads(outputs["warm_os"]) == ["ubuntu-latest"]
 
-    def test_pr_with_full_ci_label_writes_full_matrix(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    def test_pr_with_full_ci_label_writes_full_matrix(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         out = tmp_path / "out.txt"
         monkeypatch.setenv("EVENT_NAME", "pull_request")
         monkeypatch.setenv("LABELS_JSON", '["full-ci"]')

--- a/tests/context/test_optimization_info.py
+++ b/tests/context/test_optimization_info.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 from autointent.context.optimization_info import OptimizationInfo, ScorerArtifact
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     import pytest
 
 
@@ -35,6 +34,13 @@ def test_new_best_removes_previous_dump_remote_aware(tmp_path: Path, caplog: pyt
     module = MagicMock()
     module.get_assets.return_value = ScorerArtifact()
 
+    def _fake_dump(dump_dir: str) -> None:
+        dump_path = Path(dump_dir)
+        dump_path.mkdir(parents=True, exist_ok=True)
+        (dump_path / "marker.json").write_text("{}", encoding="utf-8")
+
+    module.dump.side_effect = _fake_dump
+
     first_dump = tmp_path / "trial0"
     first_dump.mkdir()
     (first_dump / "remote_manifest.json").write_text(
@@ -50,3 +56,29 @@ def test_new_best_removes_previous_dump_remote_aware(tmp_path: Path, caplog: pyt
 
     assert not first_dump.exists()
     assert "some-future-engine" in caplog.text  # proves remove_module_dump ran, not bare rmtree
+
+
+def test_new_best_keeps_previous_dump_when_new_dump_not_produced(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """`Dumper.dump()` swallows failures (raise_errors=False): a new-best trial's dump can
+    silently produce nothing. The previous best dump must survive in that case — otherwise
+    the pipeline is left referencing a best trial with no artifact at all."""
+    info = OptimizationInfo()
+
+    first_dump = tmp_path / "trial0"
+    first_module = MagicMock()
+    first_module.get_assets.return_value = ScorerArtifact()
+    first_module.dump.side_effect = lambda p: Path(p).mkdir(parents=True, exist_ok=True)
+    _log_trial(info, metric_value=0.5, dump_dir=str(first_dump), module=first_module)
+    assert first_dump.exists()
+
+    second_dump = tmp_path / "trial1"
+    second_module = MagicMock()  # dump() is a no-op by default: writes nothing
+    second_module.get_assets.return_value = ScorerArtifact()
+
+    with caplog.at_level(logging.WARNING):
+        _log_trial(info, metric_value=0.9, dump_dir=str(second_dump), module=second_module)
+
+    assert first_dump.exists()  # kept: the new best trial's dump was not actually produced
+    assert "keeping previous best dump" in caplog.text

--- a/tests/context/test_optimization_info.py
+++ b/tests/context/test_optimization_info.py
@@ -1,0 +1,52 @@
+"""Tests for OptimizationInfo bookkeeping around module dumps."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+from autointent.context.optimization_info import OptimizationInfo, ScorerArtifact
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _log_trial(info: OptimizationInfo, metric_value: float, dump_dir: str, module: Any) -> None:
+    info.log_module_optimization(
+        node_type="scoring",
+        module_name="knn",
+        module_params={},
+        metric_value=metric_value,
+        metric_name="accuracy",
+        metrics={"accuracy": metric_value},
+        module_dump_dir=dump_dir,
+        module=module,
+    )
+
+
+def test_new_best_removes_previous_dump_remote_aware(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Replacing the previous best must go through remove_module_dump (cluster-aware),
+    not a bare rmtree — a remote_manifest.json inside the old dump must be processed."""
+    info = OptimizationInfo()
+    module = MagicMock()
+    module.get_assets.return_value = ScorerArtifact()
+
+    first_dump = tmp_path / "trial0"
+    first_dump.mkdir()
+    (first_dump / "remote_manifest.json").write_text(
+        json.dumps({"engine": "some-future-engine", "index": "x", "dump_id": "y"}),
+        encoding="utf-8",
+    )
+    _log_trial(info, metric_value=0.5, dump_dir=str(first_dump), module=module)
+
+    second_dump = tmp_path / "trial1"
+    second_dump.mkdir()
+    with caplog.at_level(logging.WARNING):
+        _log_trial(info, metric_value=0.9, dump_dir=str(second_dump), module=module)
+
+    assert not first_dump.exists()
+    assert "some-future-engine" in caplog.text  # proves remove_module_dump ran, not bare rmtree

--- a/tests/context/test_remote_dumps.py
+++ b/tests/context/test_remote_dumps.py
@@ -1,0 +1,61 @@
+"""Tests for remote-aware dump deletion (issue #343)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+import uuid
+from pathlib import Path
+
+import pytest
+
+from autointent import remove_module_dump
+
+from .test_vector_index import _DOCKER_AVAILABLE, _one_hot_docs, _os_backend
+
+
+def test_remove_module_dump_plain_dir(tmp_path: Path) -> None:
+    """Dumps without manifests are removed exactly like shutil.rmtree."""
+    dump_dir = tmp_path / "dump"
+    (dump_dir / "nested").mkdir(parents=True)
+    (dump_dir / "nested" / "config.json").write_text("{}", encoding="utf-8")
+
+    remove_module_dump(dump_dir)
+
+    assert not dump_dir.exists()
+
+
+def test_remove_module_dump_unknown_engine_logs_and_removes(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """An unknown engine cannot be cleaned up in the cluster, but the local dir still goes."""
+    dump_dir = tmp_path / "dump"
+    dump_dir.mkdir()
+    (dump_dir / "remote_manifest.json").write_text(
+        json.dumps({"engine": "some-future-engine", "index": "x", "dump_id": "y"}),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        remove_module_dump(dump_dir)
+
+    assert not dump_dir.exists()
+    assert "some-future-engine" in caplog.text
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_remove_module_dump_deletes_cluster_generation(opensearch_container: tuple[str, int]) -> None:
+    """The generation's lifetime is exactly its dump directory's lifetime."""
+    host, port = opensearch_container
+    backend = _os_backend(host, port, f"test_gen_{uuid.uuid4().hex[:8]}")
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+
+    module_dump = Path(tempfile.mkdtemp()) / "module"
+    vector_dump = module_dump / "some" / "nesting" / "vector_index"  # helper must scan the tree
+    backend.dump(vector_dump)
+    generation = json.loads((vector_dump / "remote_manifest.json").read_text(encoding="utf-8"))["index"]
+
+    remove_module_dump(module_dump)
+
+    assert not module_dump.exists()
+    assert not backend._client.indices.exists(index=generation)

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 import sys
@@ -413,3 +414,61 @@ def test_opensearch_empty_index_query_raises_actionable_error(opensearch_contain
 
     with pytest.raises(RuntimeError, match="empty"):
         backend.query(np.zeros((1, 8)), k=3)
+
+
+def _os_backend(host: str, port: int, index_name: str | None, vector_size: int = 8) -> OpenSearchBackend:
+    config = OpenSearchConfig(hosts=[{"host": host, "port": port}], index_name=index_name)
+    return OpenSearchBackend(config=config, vector_size=vector_size)
+
+
+def _one_hot_docs(prefix: str, n: int = 4, label: int = 0) -> tuple[np.ndarray, list[Document]]:
+    """One-hot embeddings make nearest-neighbor assertions exact: query eye[i] -> doc i."""
+    return np.eye(8, dtype="float32")[:n], [Document(text=f"{prefix} {i}", label=label) for i in range(n)]
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_dump_creates_write_blocked_generation(opensearch_container: tuple[str, int]) -> None:
+    """dump() copies the live index into an immutable generation and records a manifest (issue #343)."""
+    import opensearchpy
+
+    host, port = opensearch_container
+    live_name = f"test_gen_{uuid.uuid4().hex[:8]}"
+    backend = _os_backend(host, port, live_name)
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(dump_dir)
+
+    manifest = json.loads((dump_dir / "remote_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["engine"] == "opensearch"
+    generation = manifest["index"]
+    assert generation.startswith(f"{live_name}-best-")
+    assert generation.endswith(manifest["dump_id"])
+
+    client = backend._client
+    assert client.indices.exists(index=generation)
+    assert client.count(index=generation)["count"] == 4
+
+    meta = client.indices.get_mapping(index=generation)[generation]["mappings"]["_meta"]
+    assert meta["dump_id"] == manifest["dump_id"]
+
+    with pytest.raises(opensearchpy.exceptions.TransportError):
+        client.index(index=generation, body={"values": [0.0] * 8, "text": "stray write", "label": 0})
+
+    # the pre-existing reference files are still written
+    assert (dump_dir / "config.json").exists()
+    assert (dump_dir / "vector_size.txt").exists()
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_dump_before_fit_writes_no_manifest(opensearch_container: tuple[str, int]) -> None:
+    """A never-fitted backend dumps a plain reference (no generation to copy)."""
+    host, port = opensearch_container
+    backend = _os_backend(host, port, index_name=None)
+
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(dump_dir)
+
+    assert not (dump_dir / "remote_manifest.json").exists()
+    assert (dump_dir / "config.json").exists()

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -663,3 +663,21 @@ def test_opensearch_dump_twice_to_same_path_replaces_generation(opensearch_conta
     loaded = OpenSearchBackend.load(dump_dir)
     _, results = loaded.query(np.eye(8, dtype="float32")[:1], k=1)
     assert results[0][0].text == "best 0"
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_dump_swaps_serving_alias_to_latest_generation(opensearch_container: tuple[str, int]) -> None:
+    host, port = opensearch_container
+    live_name = f"test_gen_{uuid.uuid4().hex[:8]}"
+    backend = _os_backend(host, port, live_name)
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+
+    first_dump = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(first_dump)
+    second_dump = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(second_dump)
+    latest_generation = json.loads((second_dump / "remote_manifest.json").read_text(encoding="utf-8"))["index"]
+
+    alias_targets = backend._client.indices.get_alias(name=f"{live_name}-best")
+    assert list(alias_targets) == [latest_generation]

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -596,3 +596,70 @@ def test_opensearch_delete_dumped_generation_spares_recreated_index(opensearch_c
 
     OpenSearchBackend.delete_dumped_generation(dump_dir)
     assert backend._client.indices.exists(index=generation)
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_redump_after_live_overwrite_serves_original_data(opensearch_container: tuple[str, int]) -> None:
+    """Pipeline.dump() path: re-dumping the best module after later trials rewrote the live
+    index must snapshot the module's own fitted data (sourced from its earlier generation)."""
+    host, port = opensearch_container
+    live_name = f"test_gen_{uuid.uuid4().hex[:8]}"
+
+    best = _os_backend(host, port, live_name)
+    embeddings, documents = _one_hot_docs("best")
+    best.add(embeddings, documents)
+    first_dump = Path(tempfile.mkdtemp()) / "vector_index"
+    best.dump(first_dump)  # what log_module_optimization does at is_new_best time
+
+    later = _os_backend(host, port, live_name)
+    later_embeddings, later_documents = _one_hot_docs("later", label=1)
+    later.add(later_embeddings, later_documents)  # last trial rewrites the live index
+
+    second_dump = Path(tempfile.mkdtemp()) / "vector_index"
+    best.dump(second_dump)  # what Pipeline.dump() does afterwards
+
+    loaded = OpenSearchBackend.load(second_dump)
+    _, results = loaded.query(np.eye(8, dtype="float32")[:1], k=1)
+    assert results[0][0].text == "best 0"
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_add_after_dump_makes_live_index_source_again(opensearch_container: tuple[str, int]) -> None:
+    host, port = opensearch_container
+    backend = _os_backend(host, port, f"test_gen_{uuid.uuid4().hex[:8]}")
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+    backend.dump(Path(tempfile.mkdtemp()) / "vector_index")
+
+    more_embeddings, more_documents = _one_hot_docs("more", label=2)
+    backend.add(more_embeddings, more_documents)  # second add on same instance appends to live
+
+    second_dump = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(second_dump)
+
+    loaded = OpenSearchBackend.load(second_dump)
+    assert loaded._client.count(index=loaded.index_name)["count"] == 8  # 4 "best" + 4 "more"
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_dump_twice_to_same_path_replaces_generation(opensearch_container: tuple[str, int]) -> None:
+    """A dump directory owns exactly one generation: re-dumping replaces it in the cluster."""
+    host, port = opensearch_container
+    backend = _os_backend(host, port, f"test_gen_{uuid.uuid4().hex[:8]}")
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(dump_dir)
+    first_generation = json.loads((dump_dir / "remote_manifest.json").read_text(encoding="utf-8"))["index"]
+
+    backend.dump(dump_dir)
+    second_generation = json.loads((dump_dir / "remote_manifest.json").read_text(encoding="utf-8"))["index"]
+
+    assert first_generation != second_generation
+    assert not backend._client.indices.exists(index=first_generation)
+    assert backend._client.indices.exists(index=second_generation)
+
+    loaded = OpenSearchBackend.load(dump_dir)
+    _, results = loaded.query(np.eye(8, dtype="float32")[:1], k=1)
+    assert results[0][0].text == "best 0"

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -681,3 +681,98 @@ def test_opensearch_dump_swaps_serving_alias_to_latest_generation(opensearch_con
 
     alias_targets = backend._client.indices.get_alias(name=f"{live_name}-best")
     assert list(alias_targets) == [latest_generation]
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_failed_dump_leaves_no_stranded_generation(
+    opensearch_container: tuple[str, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If copying data into the new generation fails, the generation must not be left
+    dangling in the cluster (issue #343 follow-up): nothing references it, nothing can
+    ever clean it up."""
+    host, port = opensearch_container
+    live_name = f"test_gen_{uuid.uuid4().hex[:8]}"
+    backend = _os_backend(host, port, live_name)
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+
+    def _raise_boom(source: str, dest: str) -> None:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(backend, "_copy_index", _raise_boom)
+
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    with pytest.raises(RuntimeError, match="boom"):
+        backend.dump(dump_dir)
+
+    assert backend._client.indices.get(index=f"{live_name}-best-*") == {}
+    assert not (dump_dir / "remote_manifest.json").exists()
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_alias_conflict_does_not_fail_dump(opensearch_container: tuple[str, int]) -> None:
+    """The serving alias is operator convenience, not load-bearing: a naming conflict
+    on the alias swap must not fail the dump itself."""
+    host, port = opensearch_container
+    live_name = f"test_gen_{uuid.uuid4().hex[:8]}"
+    backend = _os_backend(host, port, live_name)
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+
+    # A real INDEX (not an alias) already occupies the name the alias would need.
+    backend._client.indices.create(index=f"{live_name}-best")
+
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(dump_dir)  # must not raise despite the alias conflict
+
+    manifest = json.loads((dump_dir / "remote_manifest.json").read_text(encoding="utf-8"))
+    generation = manifest["index"]
+    assert backend._client.indices.exists(index=generation)
+
+    loaded = OpenSearchBackend.load(dump_dir)
+    _, results = loaded.query(np.eye(8, dtype="float32")[:1], k=1)
+    assert results[0][0].text == "best 0"
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_redump_of_loaded_instance(opensearch_container: tuple[str, int]) -> None:
+    """Production path: Pipeline.fit(clear_ram=True) then Pipeline.dump() loads the module
+    back from its own dump before re-dumping it; the re-dump must still work and must not
+    accumulate a nested '-best-' infix in the generation name."""
+    host, port = opensearch_container
+    live_name = f"test_gen_{uuid.uuid4().hex[:8]}"
+    backend = _os_backend(host, port, live_name)
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+
+    first_dump = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(first_dump)
+
+    loaded = OpenSearchBackend.load(first_dump)
+    second_dump = Path(tempfile.mkdtemp()) / "vector_index"
+    loaded.dump(second_dump)
+
+    served = OpenSearchBackend.load(second_dump)
+    _, results = served.query(np.eye(8, dtype="float32")[:1], k=1)
+    assert results[0][0].text == "best 0"
+
+    manifest = json.loads((second_dump / "remote_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["index"].count("-best-") == 1
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_load_raises_on_malformed_manifest(opensearch_container: tuple[str, int]) -> None:
+    """A manifest missing the expected keys must fail loudly and specifically, not with
+    an opaque KeyError."""
+    host, port = opensearch_container
+    backend = _os_backend(host, port, f"test_gen_{uuid.uuid4().hex[:8]}")
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(dump_dir)
+
+    (dump_dir / "remote_manifest.json").write_text(json.dumps({"engine": "opensearch"}), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="malformed"):
+        OpenSearchBackend.load(dump_dir)

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
-import sys
 import tempfile
 import uuid
+from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -26,8 +26,6 @@ from autointent.custom_types import Document
 from tests.conftest import get_test_embedder_config
 
 if TYPE_CHECKING:
-    from types import ModuleType
-
     import numpy.typing as npt
 
 
@@ -371,36 +369,20 @@ class TestVectorIndexEdgeCases:
             vector_index.add(["test"], [0])
 
     def test_opensearch_dependency_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test OpenSearch dependency error handling."""
-        # Mock opensearchpy import to fail
+        """require('opensearch') surfaces a clear ImportError when opensearch-py isn't installed."""
+        original_version = metadata.version
 
-        original_modules = sys.modules.copy()
+        def fake_version(name: str) -> str:
+            if name == "opensearch-py":
+                raise metadata.PackageNotFoundError(name)
+            return original_version(name)
 
-        try:
-            # Remove opensearchpy from sys.modules if it exists
-            if "opensearchpy" in sys.modules:
-                del sys.modules["opensearchpy"]
+        monkeypatch.setattr(metadata, "version", fake_version)
 
-            # Mock import to raise ImportError
-            def mock_import(name: str, *args: object, **kwargs: object) -> ModuleType | None:
-                if name == "opensearchpy":
-                    msg = "No module named opensearchpy"
-                    raise ImportError(msg)
-                return original_modules.get(name)
+        config = OpenSearchConfig(hosts=[{"host": "localhost", "port": 9200}])
 
-            monkeypatch.setattr("builtins.__import__", mock_import)
-
-            # Import the backend module fresh to trigger the import error
-            from autointent._wrappers.vector_index.opensearch import OpenSearchBackend
-
-            config = OpenSearchConfig(hosts=[{"host": "localhost", "port": 9200}])
-
-            with pytest.raises(RuntimeError, match="Install opensearch-py python package first"):
-                OpenSearchBackend(config=config, vector_size=384)
-
-        finally:
-            # Restore original modules
-            sys.modules.update(original_modules)
+        with pytest.raises(ImportError, match="opensearch-py"):
+            OpenSearchBackend(config=config, vector_size=384)
 
 
 @pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -562,3 +562,37 @@ def test_opensearch_manifestless_dump_loads_as_reference(opensearch_container: t
     assert loaded.index_name == live_name
     _, results = loaded.query(np.eye(8, dtype="float32")[:1], k=1)
     assert results[0][0].text == "best 0"
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_delete_dumped_generation_removes_index(opensearch_container: tuple[str, int]) -> None:
+    host, port = opensearch_container
+    backend = _os_backend(host, port, f"test_gen_{uuid.uuid4().hex[:8]}")
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(dump_dir)
+    generation = json.loads((dump_dir / "remote_manifest.json").read_text(encoding="utf-8"))["index"]
+
+    OpenSearchBackend.delete_dumped_generation(dump_dir)
+    assert not backend._client.indices.exists(index=generation)
+
+    OpenSearchBackend.delete_dumped_generation(dump_dir)  # idempotent: already gone is fine
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_delete_dumped_generation_spares_recreated_index(opensearch_container: tuple[str, int]) -> None:
+    """Never delete an index we don't own: dump_id mismatch means someone recreated it."""
+    host, port = opensearch_container
+    backend = _os_backend(host, port, f"test_gen_{uuid.uuid4().hex[:8]}")
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(dump_dir)
+    generation = json.loads((dump_dir / "remote_manifest.json").read_text(encoding="utf-8"))["index"]
+
+    backend._client.indices.delete(index=generation)
+    backend._client.indices.create(index=generation)  # recreated by "someone else", no _meta
+
+    OpenSearchBackend.delete_dumped_generation(dump_dir)
+    assert backend._client.indices.exists(index=generation)

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -28,6 +28,8 @@ from tests.conftest import get_test_embedder_config
 if TYPE_CHECKING:
     from types import ModuleType
 
+    import numpy.typing as npt
+
 
 def _docker_available() -> bool:
     """Detect whether Docker is reachable for testcontainers (skipped on most Windows CI)."""
@@ -421,7 +423,7 @@ def _os_backend(host: str, port: int, index_name: str | None, vector_size: int =
     return OpenSearchBackend(config=config, vector_size=vector_size)
 
 
-def _one_hot_docs(prefix: str, n: int = 4, label: int = 0) -> tuple[np.ndarray, list[Document]]:
+def _one_hot_docs(prefix: str, n: int = 4, label: int = 0) -> tuple[npt.NDArray[np.float32], list[Document]]:
     """One-hot embeddings make nearest-neighbor assertions exact: query eye[i] -> doc i."""
     return np.eye(8, dtype="float32")[:n], [Document(text=f"{prefix} {i}", label=label) for i in range(n)]
 

--- a/tests/context/test_vector_index.py
+++ b/tests/context/test_vector_index.py
@@ -472,3 +472,93 @@ def test_opensearch_dump_before_fit_writes_no_manifest(opensearch_container: tup
 
     assert not (dump_dir / "remote_manifest.json").exists()
     assert (dump_dir / "config.json").exists()
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_dumped_pipeline_survives_later_writes(opensearch_container: tuple[str, int]) -> None:
+    """THE regression test for issue #343: a dump serves the data present at dump time,
+    even after later trials rewrite — or someone deletes — the live index."""
+    host, port = opensearch_container
+    live_name = f"test_gen_{uuid.uuid4().hex[:8]}"
+
+    best = _os_backend(host, port, live_name)
+    embeddings, documents = _one_hot_docs("best")
+    best.add(embeddings, documents)
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    best.dump(dump_dir)
+
+    later = _os_backend(host, port, live_name)  # next trial: fresh instance, fit-replaces
+    later_embeddings, later_documents = _one_hot_docs("later", label=1)
+    later.add(later_embeddings, later_documents)
+
+    best._client.indices.delete(index=live_name)  # even destroying the live index is fine
+
+    loaded = OpenSearchBackend.load(dump_dir)
+    _, results = loaded.query(np.eye(8, dtype="float32")[:1], k=1)
+    assert results[0][0].text == "best 0"
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_load_raises_when_generation_missing(opensearch_container: tuple[str, int]) -> None:
+    host, port = opensearch_container
+    backend = _os_backend(host, port, f"test_gen_{uuid.uuid4().hex[:8]}")
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(dump_dir)
+
+    generation = json.loads((dump_dir / "remote_manifest.json").read_text(encoding="utf-8"))["index"]
+    backend._client.indices.delete(index=generation)
+
+    with pytest.raises(RuntimeError, match="no longer exists or was recreated"):
+        OpenSearchBackend.load(dump_dir)
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_load_raises_when_generation_recreated(opensearch_container: tuple[str, int]) -> None:
+    """A same-named index without our dump_id is somebody else's index — refuse, don't serve it."""
+    host, port = opensearch_container
+    backend = _os_backend(host, port, f"test_gen_{uuid.uuid4().hex[:8]}")
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(dump_dir)
+
+    generation = json.loads((dump_dir / "remote_manifest.json").read_text(encoding="utf-8"))["index"]
+    backend._client.indices.delete(index=generation)
+    backend._client.indices.create(index=generation)  # recreated, no _meta.dump_id
+
+    with pytest.raises(RuntimeError, match="no longer exists or was recreated"):
+        OpenSearchBackend.load(dump_dir)
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_loaded_instance_rejects_writes(opensearch_container: tuple[str, int]) -> None:
+    host, port = opensearch_container
+    backend = _os_backend(host, port, f"test_gen_{uuid.uuid4().hex[:8]}")
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(dump_dir)
+
+    loaded = OpenSearchBackend.load(dump_dir)
+    with pytest.raises(RuntimeError, match="immutable"):
+        loaded.add(embeddings, documents)
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker not available; testcontainers cannot boot OpenSearch")
+def test_opensearch_manifestless_dump_loads_as_reference(opensearch_container: tuple[str, int]) -> None:
+    """Backward compatibility: dumps created before #343 (no manifest) keep today's semantics."""
+    host, port = opensearch_container
+    live_name = f"test_gen_{uuid.uuid4().hex[:8]}"
+    backend = _os_backend(host, port, live_name)
+    embeddings, documents = _one_hot_docs("best")
+    backend.add(embeddings, documents)
+    dump_dir = Path(tempfile.mkdtemp()) / "vector_index"
+    backend.dump(dump_dir)
+    (dump_dir / "remote_manifest.json").unlink()  # simulate a pre-#343 dump
+
+    loaded = OpenSearchBackend.load(dump_dir)
+    assert loaded.index_name == live_name
+    _, results = loaded.query(np.eye(8, dtype="float32")[:1], k=1)
+    assert results[0][0].text == "best 0"

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -35,6 +35,7 @@ def _patch_metadata(
     requires_map: {dist_name: [PEP 508 requirement string, ...]}
     versions:     {dist_name: installed_version_string}  (absent key => not installed)
     """
+
     def fake_requires(dist: str) -> list[str]:
         # Mirror the real importlib.metadata.requires: a dist with no metadata
         # (i.e. not installed) raises PackageNotFoundError rather than returning [].
@@ -81,12 +82,14 @@ def test_check_reports_outdated(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_iter_extra_reqs_selects_only_extra_members(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_metadata(
         monkeypatch,
-        {"autointent": [
-            "numpy>=1.0 ; python_version >= '3.0'",          # base dep w/ env marker -> excluded
-            "torch>=2.0",                                     # base dep, no marker -> excluded
-            "catboost>=1.2.8,<2.0.0 ; extra == 'catboost'",  # extra member -> included
-            "peft>=0.10.0 ; extra == 'peft'",                # different extra -> excluded
-        ]},
+        {
+            "autointent": [
+                "numpy>=1.0 ; python_version >= '3.0'",  # base dep w/ env marker -> excluded
+                "torch>=2.0",  # base dep, no marker -> excluded
+                "catboost>=1.2.8,<2.0.0 ; extra == 'catboost'",  # extra member -> included
+                "peft>=0.10.0 ; extra == 'peft'",  # different extra -> excluded
+            ]
+        },
         {},
     )
     reqs = deps._iter_extra_reqs("autointent", "catboost")
@@ -119,10 +122,12 @@ def test_resolve_recurses_into_nested_extra(monkeypatch: pytest.MonkeyPatch) -> 
 def test_resolve_terminates_on_cycle(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_metadata(
         monkeypatch,
-        {"pkg": [
-            "pkg[b]>=1.0 ; extra == 'a'",
-            "pkg[a]>=1.0 ; extra == 'b'",
-        ]},
+        {
+            "pkg": [
+                "pkg[b]>=1.0 ; extra == 'a'",
+                "pkg[a]>=1.0 ; extra == 'b'",
+            ]
+        },
         {},
     )
     reqs = deps._resolve("pkg", "a", set())


### PR DESCRIPTION
Closes #343.

## Invariant restored

A dumped pipeline serves the data its module was fitted on at dump time. Previously `OpenSearchBackend.dump()` wrote only a *reference* to the live index, which every subsequent HPO trial rewrites — so a loaded pipeline served whatever the last trial wrote (reproduced in the issue's investigation comment).

## Design (as proposed in #343)

- `dump()` copies the live index server-side (`_reindex`, task-polled) into a write-blocked generation index `{base}-best-{uuid}`, stamps `mappings._meta.dump_id`, and records it in `remote_manifest.json`. Data never leaves the cluster.
- `load()` binds read-only to the verified generation; it raises loudly if the generation is missing, was recreated (`dump_id` mismatch), or the manifest is malformed. Manifest-less (pre-existing) dumps keep the old reference semantics.
- `remove_module_dump()` (new, public) deletes a dump tree together with the cluster indices its manifests reference; the HPO best-trial replacement now uses it instead of a bare `rmtree`, so steady-state cluster footprint during optimization is the live scratch index plus one generation per node type.

## Additions beyond the issue text (from the investigation)

- Re-dumps source from the module's existing generation when no write happened since (`Pipeline.dump()` after optimization would otherwise snapshot the *last* trial's live contents).
- A dump directory owns exactly one generation: re-dumping to the same path replaces the old generation in the cluster.
- Serving alias `{base}-best` tracks the latest generation (operator convenience; `load()` deliberately ignores it, and a failed alias swap never fails the dump).
- Failure-path hardening: a dump that fails mid-copy deletes its partial generation and re-raises (no stranded write-blocked indices), and the HPO loop keeps the previous best dump when a new best trial's dump was not actually produced.

## Tests

Backend-level integration tests against an OpenSearch testcontainer: the #343 regression (dump survives later rewrites *and* deletion of the live index), loud load failures (missing / recreated / malformed manifest), write-block enforcement (server- and client-side), generation lifecycle (ownership-checked deletion, same-path replacement, generation-sourced re-dump, re-dump of a loaded read-only instance, failed-dump cleanup, alias-conflict tolerance), plus `OptimizationInfo` wiring tests proving best-trial replacement goes through the remote-aware helper and spares the previous dump when the new one is missing.

Docs: new "Vector Index Lifecycle" section in `concepts.rst` (portability trade-off, cleanup story, read-only serving pattern, `-best-` naming caveat, `n_jobs = 1` caveat for OpenSearch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
